### PR TITLE
fix query example table

### DIFF
--- a/src/component/QueryExamples.tsx
+++ b/src/component/QueryExamples.tsx
@@ -56,9 +56,9 @@ class QueryExamples extends React.Component<{}> {
         return (
             <Table responsive>
                 <thead>
-                    <tr className="d-flex justify-content-center">
-                        <th className="col-6">Resource</th>
-                        <th className="col-4">Description</th>
+                    <tr>
+                        <th>Resource</th>
+                        <th>Description</th>
                     </tr>
                 </thead>
                 <tbody>{QUERY_EXAMPLE_ELEMENTS}</tbody>
@@ -69,9 +69,8 @@ class QueryExamples extends React.Component<{}> {
     @autobind
     private queryExampleToElement(queryExample: QueryExample) {
         return (
-            <tr className="d-flex justify-content-center">
+            <tr>
                 <td
-                    className="col-6"
                     style={{
                         textOverflow: 'ellipsis',
                         overflow: 'hidden',
@@ -84,7 +83,7 @@ class QueryExamples extends React.Component<{}> {
                         rel="noopener noreferrer"
                     >{`GET ${queryExample.url}`}</a>
                 </td>
-                <td className="col-4">{queryExample.description}</td>
+                <td>{queryExample.description}</td>
             </tr>
         );
     }

--- a/src/page/Home.css
+++ b/src/page/Home.css
@@ -23,11 +23,13 @@
 #home-query-example-header {
     margin: 8rem auto 3rem;
     font-size: 1.625rem;
+    padding-left: 20%;
 }
 
 #home-query-example-table {
     margin: auto auto 8rem;
-    font-size: 1.125rem;
+    font-size: 1rem;
+    max-width: 1600px;
 }
 
 #search-box .form-control {

--- a/src/page/Home.tsx
+++ b/src/page/Home.tsx
@@ -101,12 +101,10 @@ class Home extends React.Component<{ history: any }> {
 
                 <div id="home-example-container">
                     <Row>
-                        <Col lg="6" id="home-query-example-header">
-                            Query Examples
-                        </Col>
+                        <Col id="home-query-example-header">Query Examples</Col>
                     </Row>
                     <Row>
-                        <Col lg="8" id="home-query-example-table">
+                        <Col lg="10" id="home-query-example-table">
                             <QueryExamples />
                         </Col>
                     </Row>


### PR DESCRIPTION
- show full url in the table
- use more space on small screen

fix:https://github.com/genome-nexus/genome-nexus/issues/333