### PR TITLE
remove links from footer

### DIFF
--- a/src/component/Footer.tsx
+++ b/src/component/Footer.tsx
@@ -53,17 +53,8 @@ class Footer extends React.Component<{}> {
             <footer className="mskcc-footer bg-mskcc-footer d-none d-md-block">
                 <Container>
                     <Row className="text-center">
-                        <Col>{this.externalLinks}</Col>
-                    </Row>
-                    <Row className="text-center">
                         <Col md={true} className="m-auto">
                             {this.internalLinks}
-                        </Col>
-                        <Col md={true} className="m-auto">
-                            <div>
-                                &copy; 2019 Memorial Sloan Kettering Cancer
-                                Center
-                            </div>
                         </Col>
                     </Row>
                 </Container>

--- a/src/page/Main.tsx
+++ b/src/page/Main.tsx
@@ -30,7 +30,7 @@ class Main extends React.Component<{}> {
                             marginLeft: '2rem',
                             marginRight: '2rem',
                             paddingTop: 20,
-                            paddingBottom: 78,
+                            paddingBottom: 49,
                             fontSize: '1.25rem',
                             color: '#2c3e50',
                         }}


### PR DESCRIPTION
fix https://github.com/genome-nexus/genome-nexus/issues/337

TODO: the `contact us` still points to `info@genomenexus.org`, we can update it once we have the google group