### PR TITLE
fix search box validator

### DIFF
--- a/src/util/variantValidator.tsx
+++ b/src/util/variantValidator.tsx
@@ -36,7 +36,7 @@ export function isVariantValid(variant: string): VariantValidStatus {
         // SNP
         if (variant.includes(VARIANT_OPERATOR.SNP)) {
             // chromosome(1-24,X,Y,MT) + start(number) + ref(A/T/G/C) + ">" + var(A/T/G/C)
-            pattern = /\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*[ATGC]>[ATGC]/i;
+            pattern = /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*[ATGC]>[ATGC]$/i;
             if (variant.trim().match(pattern)) {
                 return {
                     isValid: true,
@@ -48,7 +48,7 @@ export function isVariantValid(variant: string): VariantValidStatus {
         // DELINS
         else if (variant.includes(VARIANT_OPERATOR.DELINS)) {
             // chromosome(1-24,X,Y,MT) + start(number) + "_" + end(number) + "delins" + var(ATGC)
-            pattern = /\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*_[0-9]*(delins)[ATGC]*/i;
+            pattern = /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*_[0-9]*(delins)[ATGC]*$/i;
             if (variant.trim().match(pattern)) {
                 return {
                     isValid: true,
@@ -60,7 +60,7 @@ export function isVariantValid(variant: string): VariantValidStatus {
         // INS
         else if (variant.includes(VARIANT_OPERATOR.INS)) {
             // chromosome(1-24,X,Y,MT) + start(number) + "_" + end(number) + "ins" + var(ATGC)
-            pattern = /\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*_[0-9]*(ins)[ATGC]*/i;
+            pattern = /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*_[0-9]*(ins)[ATGC]*$/i;
             if (variant.trim().match(pattern)) {
                 return {
                     isValid: true,
@@ -71,7 +71,7 @@ export function isVariantValid(variant: string): VariantValidStatus {
 
         // DEL
         else if (variant.includes(VARIANT_OPERATOR.DEL)) {
-            pattern = /\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*_[0-9]*(del)/i;
+            pattern = /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*_[0-9]*(del)$/i;
             if (variant.trim().match(pattern)) {
                 return {
                     isValid: true,
@@ -82,7 +82,7 @@ export function isVariantValid(variant: string): VariantValidStatus {
 
         // DUP
         else if (variant.includes(VARIANT_OPERATOR.DUP)) {
-            pattern = /\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*_[0-9]*(dup)/i;
+            pattern = /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*_[0-9]*(dup)$/i;
             if (variant.trim().match(pattern)) {
                 return {
                     isValid: true,


### PR DESCRIPTION
make sure the variant exactly matches the regex.

For example `17:g.41242962_41242963ins` shouldn't match the regex.

fix https://github.com/genome-nexus/genome-nexus/issues/343