### PR TITLE
Add gnomad and dbsnp to variant page

### DIFF
--- a/src/component/GenomeNexusMutationMapper.tsx
+++ b/src/component/GenomeNexusMutationMapper.tsx
@@ -25,8 +25,8 @@ class GenomeNexusMutationMapper extends ReactMutationMapper<
     @computed
     protected get geneWidth() {
         if (this.lollipopPlotGeneX) {
-            if (this.windowWrapper.size.width >= 1400) {
-                return 1240;
+            if (this.windowWrapper.size.width >= 1440) {
+                return 1260;
             } else {
                 return (
                     this.windowWrapper.size.width * 0.93 -

--- a/src/component/GenomeNexusMutationMapper.tsx
+++ b/src/component/GenomeNexusMutationMapper.tsx
@@ -25,7 +25,14 @@ class GenomeNexusMutationMapper extends ReactMutationMapper<
     @computed
     protected get geneWidth() {
         if (this.lollipopPlotGeneX) {
-            return this.windowWrapper.size.width * 0.9 - this.lollipopPlotGeneX;
+            if (this.windowWrapper.size.width >= 1400) {
+                return 1240;
+            } else {
+                return (
+                    this.windowWrapper.size.width * 0.93 -
+                    this.lollipopPlotGeneX
+                );
+            }
         } else {
             return 640;
         }

--- a/src/component/GenomeNexusMutationMapper.tsx
+++ b/src/component/GenomeNexusMutationMapper.tsx
@@ -25,8 +25,8 @@ class GenomeNexusMutationMapper extends ReactMutationMapper<
     @computed
     protected get geneWidth() {
         if (this.lollipopPlotGeneX) {
-            if (this.windowWrapper.size.width >= 1440) {
-                return 1260;
+            if (this.windowWrapper.size.width >= 1391) {
+                return 1220;
             } else {
                 return (
                     this.windowWrapper.size.width * 0.93 -

--- a/src/component/variantPage/BasicInfo.tsx
+++ b/src/component/variantPage/BasicInfo.tsx
@@ -100,7 +100,7 @@ class BasicInfo extends React.Component<IBasicInfoProps> {
                     {' '}
                     {_.map(renderData, data => {
                         return (
-                            <Col lg="4">
+                            <Col lg="4" md="6">
                                 {BasicInfoUnit(data.name, data.value, data.key)}
                             </Col>
                         );
@@ -114,10 +114,10 @@ class BasicInfo extends React.Component<IBasicInfoProps> {
 function BasicInfoUnit(field: string, data: string | undefined, key: string) {
     return (
         <Row key={key}>
-            <Col lg="4" className="fieldName">
+            <Col lg="5" className="fieldName">
                 {field}
             </Col>
-            <Col lg="8" className="data">
+            <Col lg="7" className="data">
                 {data === undefined ? 'N/A' : data}
             </Col>
         </Row>

--- a/src/component/variantPage/FunctionalGroups.css
+++ b/src/component/variantPage/FunctionalGroups.css
@@ -2,14 +2,19 @@
     background-color: #f2f2f2;
     font-size: 1rem;
     font-weight: bold;
-    margin-top: 5px;
-    margin-bottom: 5px;
+    margin-top: 3px;
+    margin-bottom: 3px;
+    padding-bottom: 4px;
+    padding-top: 4px;
+    max-width: 27%;
     vertical-align: middle;
 }
 
 .data-content {
-    margin-top: 5px;
-    margin-bottom: 5px;
+    margin-top: 3px;
+    margin-bottom: 3px;
+    padding-bottom: 4px;
+    padding-top: 4px;
 }
 
 .data-scouce {
@@ -18,8 +23,14 @@
     vertical-align: middle;
 }
 
-/* gnomad */
+/* gnomad and dbsnp */
 .gnomad {
+    font-size: 1rem;
+    font-weight: bold;
+    vertical-align: middle;
+}
+
+.dbsnp {
     font-size: 1rem;
     font-weight: bold;
     vertical-align: middle;

--- a/src/component/variantPage/FunctionalGroups.css
+++ b/src/component/variantPage/FunctionalGroups.css
@@ -7,7 +7,8 @@
     padding-bottom: 4px;
     padding-top: 4px;
     max-width: 27%;
-    vertical-align: middle;
+    display: flex;
+    align-items: center;
 }
 
 .data-content {
@@ -15,6 +16,8 @@
     margin-bottom: 3px;
     padding-bottom: 4px;
     padding-top: 4px;
+    display: flex;
+    align-items: center;
 }
 
 .data-scouce {
@@ -23,13 +26,14 @@
     vertical-align: middle;
 }
 
-/* gnomad and dbsnp */
+/* gnomad */
 .gnomad {
     font-size: 1rem;
     font-weight: bold;
     vertical-align: middle;
 }
 
+/* dbsnp */
 .dbsnp {
     font-size: 1rem;
     font-weight: bold;

--- a/src/component/variantPage/FunctionalGroups.css
+++ b/src/component/variantPage/FunctionalGroups.css
@@ -1,0 +1,26 @@
+.group-name {
+    background-color: #f2f2f2;
+    font-size: 1rem;
+    font-weight: bold;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    vertical-align: middle;
+}
+
+.data-content {
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+.data-scouce {
+    font-weight: normal;
+    font-size: 0.75rem;
+    vertical-align: middle;
+}
+
+/* gnomad */
+.gnomad {
+    font-size: 1rem;
+    font-weight: bold;
+    vertical-align: middle;
+}

--- a/src/component/variantPage/FunctionalGroups.tsx
+++ b/src/component/variantPage/FunctionalGroups.tsx
@@ -7,7 +7,7 @@ import PopulationPrevalence from './PopulationPrevalence';
 import './FunctionalGroups.css';
 
 interface IFunctionalGroupsProps {
-    annotationInternal?: VariantAnnotationSummary | undefined;
+    annotationInternal?: VariantAnnotationSummary;
     myVariantInfo?: MyVariantInfo;
 }
 
@@ -38,6 +38,12 @@ class FunctionalGroups extends React.Component<IFunctionalGroupsProps> {
                     <Col>
                         <PopulationPrevalence
                             myVariantInfo={this.props.myVariantInfo}
+                            chromosome={
+                                this.props.annotationInternal
+                                    ? this.props.annotationInternal
+                                          .genomicLocation.chromosome
+                                    : null
+                            }
                         />
                     </Col>
                 </Row>

--- a/src/component/variantPage/FunctionalGroups.tsx
+++ b/src/component/variantPage/FunctionalGroups.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import { Row, Col } from 'react-bootstrap';
+import { VariantAnnotationSummary } from 'cbioportal-frontend-commons';
+import { MyVariantInfo } from 'cbioportal-frontend-commons/api/generated/GenomeNexusAPIInternal';
+import PopulationPrevalence from './PopulationPrevalence';
+import './FunctionalGroups.css';
+
+interface IFunctionalGroupsProps {
+    annotationInternal?: VariantAnnotationSummary | undefined;
+    myVariantInfo?: MyVariantInfo;
+}
+
+@observer
+class FunctionalGroups extends React.Component<IFunctionalGroupsProps> {
+    public render() {
+        return (
+            <div style={{ paddingTop: '10px', marginLeft: '2%' }}>
+                <Row>
+                    <Col lg="2" className="group-name">
+                        Therapeutic implication:
+                    </Col>
+                </Row>
+                <Row>
+                    <Col lg="2" className="group-name">
+                        Biological function:
+                    </Col>
+                </Row>
+                <Row>
+                    <Col lg="2" className="group-name">
+                        Functional prediction:
+                    </Col>
+                </Row>
+                <Row>
+                    <Col lg="2" className="group-name">
+                        Population prevalence:
+                    </Col>
+                    <Col className="data-content">
+                        <PopulationPrevalence
+                            myVariantInfo={this.props.myVariantInfo}
+                        />
+                    </Col>
+                </Row>
+            </div>
+        );
+    }
+}
+
+export default FunctionalGroups;

--- a/src/component/variantPage/FunctionalGroups.tsx
+++ b/src/component/variantPage/FunctionalGroups.tsx
@@ -35,7 +35,7 @@ class FunctionalGroups extends React.Component<IFunctionalGroupsProps> {
                     <Col lg="2" className="group-name">
                         Population prevalence:
                     </Col>
-                    <Col className="data-content">
+                    <Col>
                         <PopulationPrevalence
                             myVariantInfo={this.props.myVariantInfo}
                         />

--- a/src/component/variantPage/PopulationPrevalence.tsx
+++ b/src/component/variantPage/PopulationPrevalence.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import './FunctionalGroups';
 import { observer } from 'mobx-react';
 import { Row, Col } from 'react-bootstrap';
-import { MyVariantInfo } from 'cbioportal-frontend-commons';
+import {
+    MyVariantInfo,
+    DefaultTooltip,
+} from 'cbioportal-frontend-commons';
 
 import { GnomadFrequency } from 'react-mutation-mapper';
 
@@ -12,7 +15,7 @@ interface IPopulationPrevalenceProps {
 
 @observer
 class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
-    private gnomadData() {
+    private gnomad() {
         if (this.props.myVariantInfo) {
             return <GnomadFrequency myVariantInfo={this.props.myVariantInfo} />;
         } else {
@@ -20,12 +23,47 @@ class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
         }
     }
 
+    private dbsnp() {
+        if (
+            this.props.myVariantInfo &&
+            this.props.myVariantInfo.dbsnp &&
+            this.props.myVariantInfo.dbsnp.rsid
+        ) {
+            console.log(`https://www.ncbi.nlm.nih.gov/snp/${this.props.myVariantInfo.dbsnp.rsid}`)
+            return (
+                <DefaultTooltip
+                    placement="top"
+                    overlay={
+                        <span>
+                            <a
+                                href={`https://www.ncbi.nlm.nih.gov/snp/${this.props.myVariantInfo.dbsnp.rsid}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                <span>Click here to see variant on dbSNP website.</span>
+                            </a>
+                        </span>
+                    }
+                >
+                    <span>{this.props.myVariantInfo.dbsnp.rsid}</span>
+                </DefaultTooltip>
+            );
+        }
+        else {
+            return "N/A";
+        }
+    }
+
     public render() {
         return (
-            <Row>
+            <Row className="data-content">
                 <Col lg="2">
-                    <span className="gnomad">{this.gnomadData()}</span>
+                    <span className="gnomad">{this.gnomad()}</span>
                     <span className="data-scouce">&nbsp;[gnomAD]</span>
+                </Col>
+                <Col lg="2">
+                    <span className="dbsnp">{this.dbsnp()}</span>
+                    <span className="data-scouce">&nbsp;[dbSNP]</span>
                 </Col>
             </Row>
         );

--- a/src/component/variantPage/PopulationPrevalence.tsx
+++ b/src/component/variantPage/PopulationPrevalence.tsx
@@ -2,10 +2,7 @@ import * as React from 'react';
 import './FunctionalGroups';
 import { observer } from 'mobx-react';
 import { Row, Col } from 'react-bootstrap';
-import {
-    MyVariantInfo,
-    DefaultTooltip,
-} from 'cbioportal-frontend-commons';
+import { MyVariantInfo, DefaultTooltip } from 'cbioportal-frontend-commons';
 
 import { GnomadFrequency } from 'react-mutation-mapper';
 
@@ -29,7 +26,6 @@ class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
             this.props.myVariantInfo.dbsnp &&
             this.props.myVariantInfo.dbsnp.rsid
         ) {
-            console.log(`https://www.ncbi.nlm.nih.gov/snp/${this.props.myVariantInfo.dbsnp.rsid}`)
             return (
                 <DefaultTooltip
                     placement="top"
@@ -40,7 +36,9 @@ class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >
-                                <span>Click here to see variant on dbSNP website.</span>
+                                <span>
+                                    Click here to see variant on dbSNP website.
+                                </span>
                             </a>
                         </span>
                     }
@@ -48,9 +46,8 @@ class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
                     <span>{this.props.myVariantInfo.dbsnp.rsid}</span>
                 </DefaultTooltip>
             );
-        }
-        else {
-            return "N/A";
+        } else {
+            return 'N/A';
         }
     }
 

--- a/src/component/variantPage/PopulationPrevalence.tsx
+++ b/src/component/variantPage/PopulationPrevalence.tsx
@@ -19,7 +19,7 @@ type Vcf = {
 };
 @observer
 class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
-    private gnomad() {
+    public gnomad() {
         if (this.props.myVariantInfo) {
             return <GnomadFrequency myVariantInfo={this.props.myVariantInfo} />;
         } else {
@@ -27,10 +27,11 @@ class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
         }
     }
 
-    public generateGnomadUrl(
+    public generateGnomadTooltip(
         myVariantInfo: MyVariantInfo | undefined,
         chromosome: string | null
     ) {
+        let gnomadUrl = '';
         if (myVariantInfo && myVariantInfo.vcf && chromosome) {
             const vcfVariant: Vcf = {
                 chrom: chromosome,
@@ -38,13 +39,36 @@ class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
                 alt: myVariantInfo.vcf.alt,
                 pos: Number(myVariantInfo.vcf.position),
             };
-            return `https://gnomad.broadinstitute.org/variant/${vcfVariant.chrom}-${vcfVariant.pos}-${vcfVariant.ref}-${vcfVariant.alt}`;
+            gnomadUrl = `https://gnomad.broadinstitute.org/variant/${vcfVariant.chrom}-${vcfVariant.pos}-${vcfVariant.ref}-${vcfVariant.alt}`;
         } else {
-            return 'https://www.ncbi.nlm.nih.gov/snp/';
+            gnomadUrl = 'https://www.ncbi.nlm.nih.gov/snp/';
         }
+        return (
+            <DefaultTooltip
+                placement="top"
+                overlay={
+                    <span>
+                        gnomAD population allele frequencies. Overall population
+                        <br />
+                        allele frequency is shown. Hover over a frequency to see
+                        <br />
+                        the frequency for each specific population. <br />
+                        <a
+                            href={gnomadUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            <span>Click to see variant on gnomAD website.</span>
+                        </a>
+                    </span>
+                }
+            >
+                <span className="data-scouce">&nbsp;[gnomAD]</span>
+            </DefaultTooltip>
+        );
     }
 
-    private dbsnp() {
+    public dbsnp() {
         if (
             this.props.myVariantInfo &&
             this.props.myVariantInfo.dbsnp &&
@@ -55,6 +79,7 @@ class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
                     placement="top"
                     overlay={
                         <span>
+                            dbSNP ID.&nbsp;
                             <a
                                 href={`https://www.ncbi.nlm.nih.gov/snp/${this.props.myVariantInfo.dbsnp.rsid}`}
                                 target="_blank"
@@ -75,36 +100,56 @@ class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
         }
     }
 
+    public generateDbsnpToolTip(myVariantInfo: MyVariantInfo | undefined) {
+        let dbsnpUrl = '';
+        if (myVariantInfo && myVariantInfo.dbsnp && myVariantInfo.dbsnp.rsid) {
+            dbsnpUrl = `https://www.ncbi.nlm.nih.gov/snp/${myVariantInfo.dbsnp.rsid}`;
+        } else {
+            dbsnpUrl = 'https://www.ncbi.nlm.nih.gov/snp/';
+        }
+        return (
+            <DefaultTooltip
+                placement="top"
+                overlay={
+                    <span>
+                        The Single Nucleotide Polymorphism Database (dbSNP)
+                        <br />
+                        is a free public archive for genetic variation within
+                        and
+                        <br />
+                        across different species. <br />
+                        <a
+                            href={dbsnpUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            <span>Click to see variant on dbSNP website.</span>
+                        </a>
+                    </span>
+                }
+            >
+                <span className="data-scouce">&nbsp;[dbSNP]</span>
+            </DefaultTooltip>
+        );
+    }
+
     public render() {
         return (
             <Row className="data-content">
                 <Col lg="2">
                     <span className="gnomad">{this.gnomad()}</span>
-                    <DefaultTooltip
-                        placement="top"
-                        overlay={
-                            <span>
-                                <a
-                                    href={this.generateGnomadUrl(
-                                        this.props.myVariantInfo,
-                                        this.props.chromosome
-                                    )}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    <span>
-                                        Click to see variant on gnomAD website.
-                                    </span>
-                                </a>
-                            </span>
-                        }
-                    >
-                        <span className="data-scouce">&nbsp;[gnomAD]</span>
-                    </DefaultTooltip>
+                    <span>
+                        {this.generateGnomadTooltip(
+                            this.props.myVariantInfo,
+                            this.props.chromosome
+                        )}
+                    </span>
                 </Col>
                 <Col lg="2">
                     <span className="dbsnp">{this.dbsnp()}</span>
-                    <span className="data-scouce">&nbsp;[dbSNP]</span>
+                    <span>
+                        {this.generateDbsnpToolTip(this.props.myVariantInfo)}
+                    </span>
                 </Col>
             </Row>
         );

--- a/src/component/variantPage/PopulationPrevalence.tsx
+++ b/src/component/variantPage/PopulationPrevalence.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import './FunctionalGroups';
+import { observer } from 'mobx-react';
+import { Row, Col } from 'react-bootstrap';
+import { MyVariantInfo } from 'cbioportal-frontend-commons';
+
+import { GnomadFrequency } from 'react-mutation-mapper';
+
+interface IPopulationPrevalenceProps {
+    myVariantInfo: MyVariantInfo | undefined;
+}
+
+@observer
+class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
+    private gnomadData() {
+        if (this.props.myVariantInfo) {
+            return <GnomadFrequency myVariantInfo={this.props.myVariantInfo} />;
+        } else {
+            return 'N/A';
+        }
+    }
+
+    public render() {
+        return (
+            <Row>
+                <Col lg="2">
+                    <span className="gnomad">{this.gnomadData()}</span>
+                    <span className="data-scouce">&nbsp;[gnomAD]</span>
+                </Col>
+            </Row>
+        );
+    }
+}
+
+export default PopulationPrevalence;

--- a/src/component/variantPage/PopulationPrevalence.tsx
+++ b/src/component/variantPage/PopulationPrevalence.tsx
@@ -8,8 +8,15 @@ import { GnomadFrequency } from 'react-mutation-mapper';
 
 interface IPopulationPrevalenceProps {
     myVariantInfo: MyVariantInfo | undefined;
+    chromosome: string | null;
 }
 
+type Vcf = {
+    chrom: string;
+    ref: string;
+    alt: string;
+    pos: number;
+};
 @observer
 class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
     private gnomad() {
@@ -17,6 +24,23 @@ class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
             return <GnomadFrequency myVariantInfo={this.props.myVariantInfo} />;
         } else {
             return 'N/A';
+        }
+    }
+
+    public generateGnomadUrl(
+        myVariantInfo: MyVariantInfo | undefined,
+        chromosome: string | null
+    ) {
+        if (myVariantInfo && myVariantInfo.vcf && chromosome) {
+            const vcfVariant: Vcf = {
+                chrom: chromosome,
+                ref: myVariantInfo.vcf.ref,
+                alt: myVariantInfo.vcf.alt,
+                pos: Number(myVariantInfo.vcf.position),
+            };
+            return `https://gnomad.broadinstitute.org/variant/${vcfVariant.chrom}-${vcfVariant.pos}-${vcfVariant.ref}-${vcfVariant.alt}`;
+        } else {
+            return 'https://www.ncbi.nlm.nih.gov/snp/';
         }
     }
 
@@ -56,7 +80,27 @@ class PopulationPrevalence extends React.Component<IPopulationPrevalenceProps> {
             <Row className="data-content">
                 <Col lg="2">
                     <span className="gnomad">{this.gnomad()}</span>
-                    <span className="data-scouce">&nbsp;[gnomAD]</span>
+                    <DefaultTooltip
+                        placement="top"
+                        overlay={
+                            <span>
+                                <a
+                                    href={this.generateGnomadUrl(
+                                        this.props.myVariantInfo,
+                                        this.props.chromosome
+                                    )}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    <span>
+                                        Click to see variant on gnomAD website.
+                                    </span>
+                                </a>
+                            </span>
+                        }
+                    >
+                        <span className="data-scouce">&nbsp;[gnomAD]</span>
+                    </DefaultTooltip>
                 </Col>
                 <Col lg="2">
                     <span className="dbsnp">{this.dbsnp()}</span>

--- a/src/page/Variant.css
+++ b/src/page/Variant.css
@@ -15,7 +15,7 @@
 }
 
 .variant-page {
-    max-width: 1400px !important;
+    max-width: 1440px !important;
 }
 
 .variant-page-container {

--- a/src/page/Variant.css
+++ b/src/page/Variant.css
@@ -13,3 +13,12 @@
 .annotation-track-selector.small {
     width: 200px !important;
 }
+
+.variant-page {
+    max-width: 1400px !important;
+}
+
+.variant-page-container {
+    display: flex;
+    justify-content: center;
+}

--- a/src/page/Variant.css
+++ b/src/page/Variant.css
@@ -15,7 +15,7 @@
 }
 
 .variant-page {
-    max-width: 1440px !important;
+    max-width: 1391px !important;
 }
 
 .variant-page-container {

--- a/src/page/Variant.tsx
+++ b/src/page/Variant.tsx
@@ -308,6 +308,7 @@ class Variant extends React.Component<IVariantProps> {
                             <Col>
                                 <FunctionalGroups
                                     myVariantInfo={this.myVariantInfo}
+                                    annotationInternal={this.annotation}
                                 />
                             </Col>
                         </Row>

--- a/src/page/Variant.tsx
+++ b/src/page/Variant.tsx
@@ -15,6 +15,7 @@ import { Mutation, TrackName } from 'react-mutation-mapper';
 import GenomeNexusMutationMapper from '../component/GenomeNexusMutationMapper';
 import { getTranscriptConsequenceSummary } from '../util/AnnotationSummaryUtil';
 import { genomeNexusApiRoot } from './genomeNexusClientInstance';
+import FunctionalGroups from '../component/variantPage/FunctionalGroups';
 interface IVariantProps {
     variant: string;
     store: VariantStore;
@@ -38,6 +39,11 @@ class Variant extends React.Component<IVariantProps> {
     @computed
     private get annotation() {
         return this.props.store.annotation.result;
+    }
+
+    @computed
+    private get myVariantInfo() {
+        return this.props.store.myVariantInfo.result;
     }
 
     protected get isLoading() {
@@ -296,6 +302,13 @@ class Variant extends React.Component<IVariantProps> {
                         <Row>
                             <Col className="pb-3 small">
                                 {this.getMutationMapper()}
+                            </Col>
+                        </Row>
+                        <Row>
+                            <Col>
+                                <FunctionalGroups
+                                    myVariantInfo={this.myVariantInfo}
+                                />
                             </Col>
                         </Row>
                         {/* remove the d-none if have sidebar */}

--- a/src/page/Variant.tsx
+++ b/src/page/Variant.tsx
@@ -260,7 +260,7 @@ class Variant extends React.Component<IVariantProps> {
             this.loadingIndicator
         ) : (
             <div>
-                <Row>
+                <Row className="variant-page-container">
                     {/* TODO: the height should automatically change with the content */}
                     {/* remove the d-none if have sidebar */}
                     <Col
@@ -274,25 +274,29 @@ class Variant extends React.Component<IVariantProps> {
                         />
                     </Col>
                     {/* change to lg="10" if have side bar */}
-                    <Col lg="12">
+                    <Col className="variant-page">
                         {/* remove this row if have side bar */}
-                        <Row className="pl-5" style={{ fontSize: '1.3rem' }}>
-                            {this.props.variant}
+                        <Row>
+                            <Col style={{ fontSize: '1.3rem' }}>
+                                {this.props.variant}
+                            </Col>
                         </Row>
                         <Row>
-                            <Col lg="12" className="pl-5">
+                            <Col>
                                 {<BasicInfo annotation={this.annotation} />}
                             </Col>
                         </Row>
                         <Row>
-                            <Col className="pl-5">
+                            <Col>
                                 <TranscriptSummaryTable
                                     annotation={this.annotation}
                                 />
                             </Col>
                         </Row>
-                        <Row className="pl-5 pb-3 small">
-                            {this.getMutationMapper()}
+                        <Row>
+                            <Col className="pb-3 small">
+                                {this.getMutationMapper()}
+                            </Col>
                         </Row>
                         {/* remove the d-none if have sidebar */}
                         {/* the content for each resources */}

--- a/src/page/VariantStore.ts
+++ b/src/page/VariantStore.ts
@@ -2,8 +2,10 @@ import { observable } from 'mobx';
 import {
     VariantAnnotationSummary,
     remoteData,
+    MyVariantInfo,
 } from 'cbioportal-frontend-commons';
 import client from './genomeNexusClientInstance';
+import MobxPromise from 'mobxpromise';
 
 export interface VariantStoreConfig {
     variant: string;
@@ -42,6 +44,17 @@ export class VariantStore {
         },
         onError: (err: Error) => {
             // fail silently
+        },
+    });
+
+    readonly myVariantInfo: MobxPromise<MyVariantInfo> = remoteData({
+        invoke: async () => {
+            return await client.fetchMyVariantInfoAnnotationGET({
+                variant: this.variant,
+            });
+        },
+        onError: () => {
+            // fail silently, leave the error handling responsibility to the data consumer
         },
     });
 }


### PR DESCRIPTION
try with `17:g.41258551C>A`

- [x] add gnomad data to variant page
- [x] center the content
- [x] add dbsnp

TODO:
we can try different styles or design later, since we don't have much data now