### PR TITLE
style changes and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@
 - 7:g.55249071C>T (showing sensitive and resistant on Therapeutic Implication)
 - 1:g.115256529T>C (long name on Therapeutic Implication)  
 - 17:g.41226411G>A (showing sensitive with multi levels on Therapeutic Implication)
+- 3:g.178952152_178952162del (protein change differs in genome nexus(`*1069*`), oncokb(`*1069F`), cbioportal(`*1069fs*`))
 
 > This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).

--- a/src/component/variantPage/BasicInfo.module.scss
+++ b/src/component/variantPage/BasicInfo.module.scss
@@ -31,6 +31,13 @@
     // some styles here
 }
 
+.hgvsg {
+    white-space: nowrap;
+    max-width: 320px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .oncogene {
     color: $high; // red, same as gain-of-function
 }

--- a/src/component/variantPage/BasicInfo.tsx
+++ b/src/component/variantPage/BasicInfo.tsx
@@ -216,7 +216,7 @@ export default class BasicInfo extends React.Component<IBasicInfoProps> {
         parsedData.push({
             value: this.props.variant,
             key: 'hgvsg',
-            category: 'default',
+            category: 'hgvsg',
         });
         //hgvsc
         parsedData.push({

--- a/src/component/variantPage/BasicInfo.tsx
+++ b/src/component/variantPage/BasicInfo.tsx
@@ -299,10 +299,17 @@ export default class BasicInfo extends React.Component<IBasicInfoProps> {
     private getAlteration(annotation: VariantAnnotationSummary | undefined) {
         if (annotation && annotation.transcriptConsequenceSummary) {
             let alteration = annotation.transcriptConsequenceSummary.hgvspShort;
-            let startIndex = alteration && alteration.indexOf('p.') + 2; // + 2 will exclude the 'p.' in the result
-            return startIndex && startIndex !== 1
-                ? alteration.substr(startIndex)
-                : null; // !== -1 means there is no 'p.' in the string, here because the startIndex was +2 before, so have !== 1 instead
+            if (alteration) {
+                let startIndex = alteration.indexOf('p.');
+                if (startIndex === -1) {
+                    // if no 'p.' in alteration, return original alteration string
+                    return alteration;
+                } else {
+                    // if has 'p.' in alteration
+                    return alteration.substr(startIndex + 2); // remove "p." by "startIndex + 2"
+                }
+            }
+            return null;
         } else {
             return null;
         }

--- a/src/component/variantPage/BasicInfo.tsx
+++ b/src/component/variantPage/BasicInfo.tsx
@@ -202,8 +202,8 @@ export default class BasicInfo extends React.Component<IBasicInfoProps> {
         });
         // variant classification
         parsedData.push({
-            value: transcript.consequenceTerms,
-            key: 'consequenceTerms',
+            value: transcript.variantClassification,
+            key: 'variantClassification',
             category: getMutationTypeClassName(transcript),
         });
         // variant type

--- a/src/component/variantPage/BasicInfo.tsx
+++ b/src/component/variantPage/BasicInfo.tsx
@@ -299,8 +299,10 @@ export default class BasicInfo extends React.Component<IBasicInfoProps> {
     private getAlteration(annotation: VariantAnnotationSummary | undefined) {
         if (annotation && annotation.transcriptConsequenceSummary) {
             let alteration = annotation.transcriptConsequenceSummary.hgvspShort;
-            let startIndex = alteration.indexOf('p.') + 2; // + 2 will exclude the 'p.' in the result
-            return startIndex !== 1 ? alteration.substr(startIndex) : null; // !== -1 means there is no 'p.' in the string, here because the startIndex was +2 before, so have !== 1 instead
+            let startIndex = alteration && alteration.indexOf('p.') + 2; // + 2 will exclude the 'p.' in the result
+            return startIndex && startIndex !== 1
+                ? alteration.substr(startIndex)
+                : null; // !== -1 means there is no 'p.' in the string, here because the startIndex was +2 before, so have !== 1 instead
         } else {
             return null;
         }

--- a/src/component/variantPage/BiologicalFunction.tsx
+++ b/src/component/variantPage/BiologicalFunction.tsx
@@ -16,7 +16,7 @@ class BiologicalFunction extends React.Component<IBiologicalFunctionProps> {
     public render() {
         if (this.props.oncokb) {
             return (
-                <Row>
+                <Row className={functionalGroupsStyle['data-content']}>
                     <Oncokb oncokb={this.props.oncokb}></Oncokb>
                 </Row>
             );

--- a/src/component/variantPage/FunctionalPrediction.tsx
+++ b/src/component/variantPage/FunctionalPrediction.tsx
@@ -34,12 +34,17 @@ class FunctionalPrediction extends React.Component<IFunctionalPredictionProps> {
         const mutationAssessor =
             genomeNexusData.mutation_assessor &&
             genomeNexusData.mutation_assessor.annotation;
-        const siftScore = genomeNexusData.transcript_consequences[0].sift_score;
+        const siftScore =
+            genomeNexusData.transcript_consequences &&
+            genomeNexusData.transcript_consequences[0].sift_score;
         const siftPrediction =
+            genomeNexusData.transcript_consequences &&
             genomeNexusData.transcript_consequences[0].sift_prediction;
         const polyPhenScore =
+            genomeNexusData.transcript_consequences &&
             genomeNexusData.transcript_consequences[0].polyphen_score;
         const polyPhenPrediction =
+            genomeNexusData.transcript_consequences &&
             genomeNexusData.transcript_consequences[0].polyphen_prediction;
 
         return {

--- a/src/component/variantPage/TherapeuticImplication.module.scss
+++ b/src/component/variantPage/TherapeuticImplication.module.scss
@@ -15,11 +15,10 @@
 }
 
 .drugs-container {
-    display: flex;
-    align-items: center;
     margin-right: 8px;
     margin-top: 2px;
     margin-bottom: 2px;
+    display: inline-flex;
 }
 
 .resistant-text {
@@ -30,10 +29,6 @@
     font-weight: bold;
     background-color: #ee3424; // red
     color: white;
-}
-
-.data-content {
-    margin-left: 15px !important;
 }
 
 .data-source {

--- a/src/component/variantPage/TherapeuticImplication.tsx
+++ b/src/component/variantPage/TherapeuticImplication.tsx
@@ -151,7 +151,7 @@ class TherapeuticImplication extends React.Component<
         if (oncokb && oncokb.query && oncokb.query.hugoSymbol) {
             oncokbUrl = `https://oncokb.org/gene/${oncokb.query.hugoSymbol}`;
         } else {
-            oncokbUrl = 'https://oncokb.org/gene/BRCA1';
+            oncokbUrl = 'https://oncokb.org/';
         }
         return (
             <DefaultTooltip
@@ -176,10 +176,7 @@ class TherapeuticImplication extends React.Component<
                 }
             >
                 <span
-                    className={classNames(
-                        functionalGroupsStyle['data-source'],
-                        therapeuticImplication['data-source']
-                    )}
+                    className={classNames(functionalGroupsStyle['data-source'])}
                 >
                     <a
                         href={oncokbUrl}
@@ -197,25 +194,24 @@ class TherapeuticImplication extends React.Component<
         const sensitiveDrugs = this.sensitiveDrugs(this.props.oncokb);
         const resistantDrugs = this.resistantDrugs(this.props.oncokb);
         return sensitiveDrugs || resistantDrugs ? (
-            <Row
-                className={classNames(
-                    functionalGroupsStyle['data-content'],
-                    therapeuticImplication['data-content']
-                )}
-            >
-                {this.oncokbToolTip(this.props.oncokb)}
-                {sensitiveDrugs}
-                {resistantDrugs}
+            <Row className={functionalGroupsStyle['data-content']}>
+                <span className={functionalGroupsStyle['data-group-gap']}>
+                    {this.oncokbToolTip(this.props.oncokb)}
+                    {sensitiveDrugs}
+                    {resistantDrugs}
+                </span>
             </Row>
         ) : (
-            <span
-                className={classNames(
-                    functionalGroupsStyle['data-content'],
-                    functionalGroupsStyle['no-data']
-                )}
-            >
-                No data available
-            </span>
+            <Row className={functionalGroupsStyle['data-content']}>
+                <div className={functionalGroupsStyle['data-group-gap']}>
+                    {this.oncokbToolTip(this.props.oncokb)}
+                    <span
+                        className={classNames(functionalGroupsStyle['oncokb'])}
+                    >
+                        N/A
+                    </span>
+                </div>
+            </Row>
         );
     }
 }

--- a/src/component/variantPage/biologicalFunction/Oncokb.tsx
+++ b/src/component/variantPage/biologicalFunction/Oncokb.tsx
@@ -141,7 +141,12 @@ class Oncokb extends React.Component<IOncokbProps> {
             );
         } else {
             return (
-                <span className={functionalGroupsStyle['data-content']}>
+                <span
+                    className={classNames(
+                        functionalGroupsStyle['data-content'],
+                        functionalGroupsStyle['oncokb']
+                    )}
+                >
                     N/A
                 </span>
             );
@@ -160,7 +165,12 @@ class Oncokb extends React.Component<IOncokbProps> {
             return (
                 <span>
                     {this.oncokbTooltip()}
-                    <span className={functionalGroupsStyle['data-content']}>
+                    <span
+                        className={classNames(
+                            functionalGroupsStyle['data-content'],
+                            functionalGroupsStyle['oncokb']
+                        )}
+                    >
                         N/A
                     </span>
                 </span>

--- a/src/component/variantPage/functionalGroups.module.scss
+++ b/src/component/variantPage/functionalGroups.module.scss
@@ -1,6 +1,7 @@
 .functional-groups {
     padding-top: 10px;
     margin-left: 2%;
+    margin-bottom: 5%;
 }
 
 .group-name {

--- a/src/component/variantPage/functionalGroups.module.scss
+++ b/src/component/variantPage/functionalGroups.module.scss
@@ -78,3 +78,9 @@
     font-size: 1rem;
     font-weight: bold;
 }
+
+// oncokb
+.oncokb {
+    font-size: 1rem;
+    font-weight: bold;
+}

--- a/src/page/Variant.tsx
+++ b/src/page/Variant.tsx
@@ -81,7 +81,11 @@ class Variant extends React.Component<IVariantProps> {
 
     private getMutationMapper() {
         let mutation = this.variantToMutation(this.annotationSummary);
-        if (mutation[0].gene && mutation[0].gene.hugoGeneSymbol.length !== 0) {
+        if (
+            mutation[0] &&
+            mutation[0].gene &&
+            mutation[0].gene.hugoGeneSymbol.length !== 0
+        ) {
             return (
                 <GenomeNexusMutationMapper
                     genomeNexusUrl={genomeNexusApiRoot}


### PR DESCRIPTION
- fix wrong variant classification data input
- shorten the hgvsg on the top when having a long allele (show `...` at the end)
- some style changes to fix different height on the group names
- check corner cases in `functional prediction`
- fix typo url
- show N/A when no data on `Therapeutic implication`, to be consistent with others
- add margin between content and footer, make it looks better when the table is expended
- fix missing checking on alteration and mutation