### PR TITLE
Cache oncokb genes to get oncogene and tsg

### DIFF
--- a/src/component/variantPage/BasicInfo.tsx
+++ b/src/component/variantPage/BasicInfo.tsx
@@ -380,22 +380,18 @@ function getOncogeneFromOncokbGenesMap(
     oncokbGenesMap: { [hugoSymbol: string]: Gene },
     gene?: string
 ): string | null {
-    if (gene && oncokbGenesMap[gene]) {
-        if (oncokbGenesMap[gene].oncogene === true) {
-            return 'Oncogene';
-        }
-    }
-    return null;
+    return gene &&
+        oncokbGenesMap[gene] &&
+        oncokbGenesMap[gene].oncogene === true
+        ? 'Oncogene'
+        : null;
 }
 
 function getTsgFromOncokbGenesMap(
     oncokbGenesMap: { [hugoSymbol: string]: Gene },
     gene?: string
 ): string | null {
-    if (gene && oncokbGenesMap[gene]) {
-        if (oncokbGenesMap[gene].tsg === true) {
-            return 'TSG';
-        }
-    }
-    return null;
+    return gene && oncokbGenesMap[gene] && oncokbGenesMap[gene].tsg === true
+        ? 'TSG'
+        : null;
 }

--- a/src/page/OncokbClientInstance.ts
+++ b/src/page/OncokbClientInstance.ts
@@ -1,6 +1,6 @@
 import { OncoKbAPI } from 'cbioportal-frontend-commons';
 
-export const oncokbApiRoot = 'https://legacy.oncokb.org/';
+export const oncokbApiRoot = 'https://legacy.oncokb.org/api/v1';
 const oncokbClient = new OncoKbAPI(oncokbApiRoot);
 
 export default oncokbClient;

--- a/src/page/Variant.tsx
+++ b/src/page/Variant.tsx
@@ -56,11 +56,6 @@ class Variant extends React.Component<IVariantProps> {
     }
 
     @computed
-    private get oncokbVariant() {
-        return this.props.store.oncokbVariant.result;
-    }
-
-    @computed
     private get variantAnnotation() {
         return this.props.store.annotation.result
             ? this.props.store.annotation.result
@@ -68,7 +63,10 @@ class Variant extends React.Component<IVariantProps> {
     }
 
     protected get isLoading() {
-        return this.props.store.annotation.isPending;
+        return (
+            this.props.store.annotation.isPending ||
+            this.props.store.oncokbGenesMap.isPending
+        );
     }
 
     protected get loadingIndicator() {
@@ -315,27 +313,20 @@ class Variant extends React.Component<IVariantProps> {
                     <Col className="variant-page">
                         <Row>
                             <Col>
-                                {
-                                    <BasicInfo
-                                        annotation={this.annotationSummary}
-                                        mutation={
-                                            this.variantToMutation(
-                                                this.annotationSummary
-                                            )[0]
-                                        }
-                                        oncokbVariant={this.oncokbVariant}
-                                        variant={this.props.variant}
-                                    />
-                                }
-                            </Col>
-                        </Row>
-                        {/* <Row>
-                            <Col>
-                                <TranscriptSummaryTable
+                                <BasicInfo
                                     annotation={this.annotationSummary}
+                                    mutation={
+                                        this.variantToMutation(
+                                            this.annotationSummary
+                                        )[0]
+                                    }
+                                    variant={this.props.variant}
+                                    oncokbGenesMap={
+                                        this.props.store.oncokbGenesMap.result
+                                    }
                                 />
                             </Col>
-                        </Row> */}
+                        </Row>
                         <Row>
                             <Col className="pb-3 small">
                                 {this.getMutationMapper()}


### PR DESCRIPTION
cache all oncokb genes, get oncogene and tsg data by matching the hugo gene symbol

Reasons: 
-  the previous endpoint `GET /variants/lookup` hasn't been maintained for a while
-  sometimes the protein change is annotated differently in oncokb, in that case we can't match the correct data
