### PR TITLE
change homepage example accordingly based on genome build

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+# using GRCh37 Genome Nexus by default:
+REACT_APP_GENOME_NEXUS_URL=https://www.genomenexus.org
+# GRCh38 Genome Nexus url:
+# REACT_APP_GENOME_NEXUS_URL=https://grch38.genomenexus.org

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Genome-Nexus Frontend
 
+### Genome Build
+Genome Nexus supports both GRCh37 and GRCh38, by default Genome Nexus website will use the public GRCh37 Genome Nexus API.
+
+#### GRCh38
+To use GRCh38 Genome Nexus API, uncomment `REACT_APP_GENOME_NEXUS_URL=https://grch38.genomenexus.org` and comment `REACT_APP_GENOME_NEXUS_URL=https://www.genomenexus.org` in the `.env` file.
+
 ### Query examples
 - 7:g.55249071C>T (showing sensitive and resistant on Therapeutic Implication)
 - 1:g.115256529T>C (long name on Therapeutic Implication)  

--- a/src/component/SearchBox.tsx
+++ b/src/component/SearchBox.tsx
@@ -135,7 +135,7 @@ class SearchBox extends React.Component<ISearchBoxProps> {
                     defaultMenuIsOpen={true}
                     autoFocus={true}
                     filterOption={(opt: ExampleData) => opt.label !== 'custom'}
-                    placeholder={'Query a variant'}
+                    placeholder={`Query a ${this.props.placeholder} variant`}
                     ref={(ref: any) => {
                         this.selectRef = ref;
                     }}
@@ -168,7 +168,7 @@ class SearchBox extends React.Component<ISearchBoxProps> {
                     >
                         HGVS
                     </a>
-                    &nbsp;format for GRCh37 (hg19) are supported.
+                    &nbsp;format are supported.
                 </p>
             </div>
         );

--- a/src/page/Home.tsx
+++ b/src/page/Home.tsx
@@ -1,4 +1,4 @@
-import { action, observable } from 'mobx';
+import { action, observable, computed } from 'mobx';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { Image } from 'react-bootstrap';
@@ -11,8 +11,13 @@ import client from './genomeNexusClientInstance';
 import ValidatorNotification, {
     ErrorType,
 } from '../component/ValidatorNotification';
+import { VariantAnnotation } from 'cbioportal-frontend-commons';
 
-const EXAMPLE_DATA = [
+enum GENOME_BUILD {
+    GRCh37 = 'GRCh37',
+    GRCh38 = 'GRCh38',
+}
+const EXAMPLE_DATA_GRCh37 = [
     {
         value: '17:g.37880220T>C',
         label: '17:g.37880220T>C (ERBB2 L755S)',
@@ -28,6 +33,22 @@ const EXAMPLE_DATA = [
     },
 ];
 
+const EXAMPLE_DATA_GRCh38 = [
+    {
+        value: '17:g.39723967T>C',
+        label: '17:g.39723967T>C (ERBB2 L755S)',
+    },
+    { value: '7:g.55181378C>T', label: '7:g.55181378C>T (EGFR T790M)' },
+    {
+        value: '7:g.55174775_55174788delinsAC',
+        label: '7:g.55174775_55174788delinsAC (EGFR L747_T751delinsP)',
+    },
+    {
+        value: '7:g.55181324_55181325insCCA',
+        label: '7:g.55181324_55181325insCCA (EGFR H773dup)',
+    },
+];
+
 @observer
 class Home extends React.Component<{ history: any }> {
     @observable
@@ -38,6 +59,26 @@ class Home extends React.Component<{ history: any }> {
 
     @observable
     protected alertType: ErrorType = ErrorType.INVALID;
+
+    @observable
+    protected genomeBuild: string = '';
+
+    componentWillMount() {
+        this.getGenomeBuild();
+    }
+
+    async getGenomeBuild() {
+        // get genome build
+        // check if the variant has response
+        let response;
+        response = await client.fetchVariantAnnotationGET({
+            variant: '17:g.41242962_41242963insGA',
+        });
+
+        if (response) {
+            this.genomeBuild = (response as VariantAnnotation).assembly_name;
+        }
+    }
 
     public render() {
         return (
@@ -62,6 +103,7 @@ class Home extends React.Component<{ history: any }> {
                         </h2>
                         Annotation and Interpretation of Genetic Variants in
                         Cancer
+                        <h1>{this.genomeBuild}</h1>
                     </div>
 
                     <div className={'mx-auto'} style={{ width: 600 }}>
@@ -69,7 +111,7 @@ class Home extends React.Component<{ history: any }> {
                             onChange={this.onTextChange}
                             onSearch={this.onSearch}
                             height={44}
-                            exampleData={EXAMPLE_DATA}
+                            exampleData={this.exampleData}
                             placeholder={'e.g.: 7:g.140453136A>T '}
                         />
                     </div>
@@ -81,7 +123,7 @@ class Home extends React.Component<{ history: any }> {
                     >
                         <table className={'table validator-notification'}>
                             <tbody>
-                                {EXAMPLE_DATA.map(example => {
+                                {this.exampleData.map(example => {
                                     return (
                                         <tr>
                                             <td>{example.label}</td>
@@ -136,6 +178,17 @@ class Home extends React.Component<{ history: any }> {
     @action.bound
     private onClose() {
         this.alert = false;
+    }
+
+    @computed
+    get exampleData() {
+        if (this.genomeBuild === GENOME_BUILD.GRCh37) {
+            return EXAMPLE_DATA_GRCh37;
+        } else if (this.genomeBuild === GENOME_BUILD.GRCh38) {
+            return EXAMPLE_DATA_GRCh38;
+        } else {
+            return [];
+        }
     }
 }
 

--- a/src/page/Home.tsx
+++ b/src/page/Home.tsx
@@ -103,7 +103,6 @@ class Home extends React.Component<{ history: any }> {
                         </h2>
                         Annotation and Interpretation of Genetic Variants in
                         Cancer
-                        <h1>{this.genomeBuild}</h1>
                     </div>
 
                     <div className={'mx-auto'} style={{ width: 600 }}>
@@ -112,7 +111,7 @@ class Home extends React.Component<{ history: any }> {
                             onSearch={this.onSearch}
                             height={44}
                             exampleData={this.exampleData}
-                            placeholder={'e.g.: 7:g.140453136A>T '}
+                            placeholder={this.genomeBuild}
                         />
                     </div>
 

--- a/src/page/genomeNexusClientInstance.ts
+++ b/src/page/genomeNexusClientInstance.ts
@@ -4,7 +4,8 @@ export const genomeNexusApiRoot =
     process.env.NODE_ENV === 'production' &&
     !window.location.host.includes('netlify')
         ? `//${window.location.host}`
-        : 'https://www.genomenexus.org';
+        : process.env.REACT_APP_GENOME_NEXUS_URL;
+
 const client = new GenomeNexusAPI(genomeNexusApiRoot);
 
 export default client;


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/395
![image](https://user-images.githubusercontent.com/16869603/78579799-77e3b900-77ff-11ea-929f-1c2df29929b1.png)

`REACT_APP_GENOME_NEXUS_URL` is set to https://www.genomenexus.org by default,
it can be overridden to https://grch38.genomenexus.org if we want grch38 genome nexus api instance