### PR TITLE
hide mutation assessor from functional prediction

### DIFF
--- a/src/component/variantPage/BasicInfo.tsx
+++ b/src/component/variantPage/BasicInfo.tsx
@@ -340,7 +340,9 @@ export default class BasicInfo extends React.Component<IBasicInfoProps> {
                     to={
                         '/annotation/' +
                         this.props.variant +
-                        '?fields=hotspots%2Cmutation_assessor%2Cmy_variant_info%2Cptms%2Cannotation_summary'
+                        // remove mutation assessor for now
+                        // '?fields=hotspots%2Cmutation_assessor%2Cmy_variant_info%2Cptms%2Cannotation_summary'
+                        '?fields=hotspots%2Cmy_variant_info%2Cptms%2Cannotation_summary'
                     }
                     target="_blank"
                     style={{ paddingLeft: '8px', paddingRight: '8px' }}

--- a/src/component/variantPage/FunctionalPrediction.tsx
+++ b/src/component/variantPage/FunctionalPrediction.tsx
@@ -23,6 +23,10 @@ interface IFunctionalImpactData {
     polyPhenPrediction: string | undefined;
 }
 
+// hide mutation assessor for now since their server is down
+// in order to show mutation assessor, set "SHOW_MUTATION_ASSESSOR = true", uncomment 'mutation_assessor' in VariantStore.ts
+const SHOW_MUTATION_ASSESSOR = false;
+
 @observer
 class FunctionalPrediction extends React.Component<IFunctionalPredictionProps> {
     public getData(
@@ -65,12 +69,14 @@ class FunctionalPrediction extends React.Component<IFunctionalPredictionProps> {
                     polyPhenScore={data.polyPhenScore}
                     polyPhenPrediction={data.polyPhenPrediction}
                 />
-                <MutationAssessor
-                    mutationAssessor={data.mutationAssessor}
-                    isCanonicalTranscriptSelected={
-                        this.props.isCanonicalTranscriptSelected
-                    }
-                />
+                {SHOW_MUTATION_ASSESSOR && (
+                    <MutationAssessor
+                        mutationAssessor={data.mutationAssessor}
+                        isCanonicalTranscriptSelected={
+                            this.props.isCanonicalTranscriptSelected
+                        }
+                    />
+                )}
                 <Sift
                     siftScore={data.siftScore}
                     siftPrediction={data.siftPrediction}

--- a/src/page/VariantStore.ts
+++ b/src/page/VariantStore.ts
@@ -72,7 +72,8 @@ export class VariantStore {
                 fields: [
                     'annotation_summary',
                     'my_variant_info',
-                    'mutation_assessor',
+                    // TODO: uncomment mutation assessor when their server is back
+                    // 'mutation_assessor',
                 ],
             });
         },


### PR DESCRIPTION
Part of https://github.com/cBioPortal/cbioportal/issues/7691
- remove mutation assessor from functional prediction for now, because their server is down for a while
- add SHOW_MUTATION_ASSESSOR to show or hide mutation assessor
- not pull mutation assessor data for now to make data fetching faster