### PR TITLE
fix isoformOverrideSource missing in the GN query

### DIFF
--- a/src/component/variantPage/BasicInfo.tsx
+++ b/src/component/variantPage/BasicInfo.tsx
@@ -340,7 +340,9 @@ export default class BasicInfo extends React.Component<IBasicInfoProps> {
                 <Link
                     to={`/annotation/${
                         this.props.variant
-                    }?fields=${ANNOTATION_QUERY_FIELDS.join(',')}`}
+                    }?isoformOverrideSource=uniprot?fields=${ANNOTATION_QUERY_FIELDS.join(
+                        ','
+                    )}`}
                     target="_blank"
                     style={{ paddingLeft: '8px', paddingRight: '8px' }}
                 >

--- a/src/page/VariantStore.ts
+++ b/src/page/VariantStore.ts
@@ -70,6 +70,7 @@ export class VariantStore {
         invoke: async () => {
             return await client.fetchVariantAnnotationGET({
                 variant: this.variant,
+                isoformOverrideSource: 'uniprot',
                 fields: ANNOTATION_QUERY_FIELDS,
             });
         },


### PR DESCRIPTION
should have `isoformOverrideSource=uniprot` in the query