### PR TITLE
Fix search dup not working

### DIFF
--- a/src/util/SearchUtils.ts
+++ b/src/util/SearchUtils.ts
@@ -18,9 +18,9 @@ export function normalizeSearchText(keyword: string) {
             secondPart = keyword.slice(seperaterIndex + 3, keyword.length);
             type = keyword.slice(seperaterIndex + 1, seperaterIndex + 3);
         }
-        // if "del" in search text("del" should be in second part of search text after splitting by ":"), don't convert second part to upper case
+        // if "del" or "dup" in search text("del" or "dup" should be in second part of search text after splitting by ":"), don't convert second part to upper case
         // otherwire convert all to upper case except type
-        if (/del/i.test(keyword)) {
+        if (/del|dup/i.test(keyword)) {
             keyword = `${_.toUpper(firstPart)}:${type}${secondPart}`;
         } else {
             keyword = `${_.toUpper(firstPart)}:${type}${_.toUpper(secondPart)}`;


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/542

It converts "dup" to uppercase so recoder can't recognize that. Fixed by not converting to uppercase if input contains "dup"

Test: search NOTCH1:c.1586_1587dup