### PR TITLE
Use www.genomenexus.org for search box

### DIFF
--- a/src/component/SearchBox.tsx
+++ b/src/component/SearchBox.tsx
@@ -53,9 +53,8 @@ export default class SearchBox extends React.Component<ISearchBoxProps> {
     }
 
     private searchInternalDb(keyword: string): Promise<any> {
-        // TODO: this is temporary, we should do database migration and change to www.genomenexus.org
         return fetch(
-            encodeURI(`https://beta.genomenexus.org/search?keyword=${keyword}`)
+            encodeURI(`https://www.genomenexus.org/search?keyword=${keyword}`)
         );
     }
 


### PR DESCRIPTION
New genome nexus database migration is done so we could point search box api url to www.genomenexus.org