### PR TITLE
Search improvements

### DIFF
--- a/src/component/SearchBox.tsx
+++ b/src/component/SearchBox.tsx
@@ -16,7 +16,9 @@ import {
     isValidInput,
     normalizeInputFormatForDatabaseSearch,
     normalizeInputFormatForOutsideSearch,
+    normalizeSearchText,
 } from '../util/SearchUtils';
+import { isVariantValid } from '../util/variantValidator';
 
 interface ISearchBoxProps {
     styles?: CSSRule;
@@ -142,11 +144,20 @@ export default class SearchBox extends React.Component<ISearchBoxProps> {
                         .then(async (queryResponse) => {
                             const variantList = queryResponse[0].results;
                             _.forEach(variantList, (item) => {
-                                if (item && item.variant) {
-                                    options.push({
-                                        value: item.variant,
-                                        label: item.variant,
-                                    });
+                                if (
+                                    item &&
+                                    item.variant &&
+                                    isVariantValid(item.variant).isValid
+                                ) {
+                                    const hgvsg = normalizeSearchText(
+                                        item.variant
+                                    );
+                                    if (hgvsg) {
+                                        options.push({
+                                            value: hgvsg,
+                                            label: hgvsg,
+                                        });
+                                    }
                                 }
                             });
                             // enrich options with gene and protein change

--- a/src/component/variantPage/BasicInfo.tsx
+++ b/src/component/variantPage/BasicInfo.tsx
@@ -18,7 +18,7 @@ import { generateOncokbLink, ONCOKB_URL } from './biologicalFunction/Oncokb';
 
 import basicInfo from './BasicInfo.module.scss';
 import { Link } from 'react-router-dom';
-import { ANNOTATION_QUERY_FIELDS } from '../../config/configDefaults';
+import { annotationQueryFields } from '../../config/configDefaults';
 import Toggle from '../Toggle';
 
 interface IBasicInfoProps {
@@ -331,7 +331,7 @@ export default class BasicInfo extends React.Component<IBasicInfoProps> {
                 <Link
                     to={`/annotation/${
                         this.props.variant
-                    }?fields=${ANNOTATION_QUERY_FIELDS.join(',')}`}
+                    }?fields=${annotationQueryFields().join(',')}`}
                     target="_blank"
                     style={{ paddingLeft: '8px', paddingRight: '8px' }}
                 >

--- a/src/config/configDefaults.ts
+++ b/src/config/configDefaults.ts
@@ -1,10 +1,17 @@
-export const SHOW_MUTATION_ASSESSOR = true;
+export const SHOW_MUTATION_ASSESSOR = false;
 
-export const ANNOTATION_QUERY_FIELDS = [
+export function annotationQueryFields() {
+    const fields = DEFAULT_ANNOTATION_QUERY_FIELDS;
+    if (SHOW_MUTATION_ASSESSOR) {
+        fields.push('mutation_assessor');
+    }
+    return fields;
+}
+
+export const DEFAULT_ANNOTATION_QUERY_FIELDS = [
     'hotspots',
     'annotation_summary',
     'my_variant_info',
-    'mutation_assessor',
     'clinvar',
     'signal',
 ];

--- a/src/page/VariantStore.ts
+++ b/src/page/VariantStore.ts
@@ -22,7 +22,7 @@ import {
     initDefaultMutationMapperStore,
     DataFilterType,
 } from 'react-mutation-mapper';
-import { ANNOTATION_QUERY_FIELDS } from '../config/configDefaults';
+import { annotationQueryFields } from '../config/configDefaults';
 import { getTranscriptConsequenceSummary } from '../util/AnnotationSummaryUtil';
 
 export interface VariantStoreConfig {
@@ -80,7 +80,7 @@ export class VariantStore {
         invoke: async () => {
             return await client.fetchVariantAnnotationGET({
                 variant: this.variant,
-                fields: ANNOTATION_QUERY_FIELDS,
+                fields: annotationQueryFields(),
             });
         },
         onError: (err: Error) => {

--- a/src/util/variantValidator.tsx
+++ b/src/util/variantValidator.tsx
@@ -50,7 +50,7 @@ export function isVariantValid(variant: string): VariantValidStatus {
         else if (variant.includes(VARIANT_OPERATOR.DELINS)) {
             // chromosome(1-24,X,Y,MT) + start(number) + "_" + end(number) + "delins" + var(ATGC)
             pattern =
-                /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*_[0-9]*(delins)[ATGC]*$/i;
+                /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*(?:_([0-9]*))?(delins)[ATGC]*$/i;
             if (variant.trim().match(pattern)) {
                 return {
                     isValid: true,


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/577

- Merge duplicated variants from search result (e.g. search `BRAF V600E` and there are two variants `7:g.140453136A>T` and `7:g.140453136A>t`, but they should be merged because they are the same variant)
![screenshot-www genomenexus org-2021 12 20-18_12_51](https://user-images.githubusercontent.com/16869603/146844991-17a311f4-2cf8-4d58-96b6-568667ef855c.png)
    - Test:  search BRAF V600E
- Remove wrong variants (e.g. `7:g.140453136A>T;7:g.140253136A>C` This is an invalid variant id, should be a single variant instead of two, this is cached by wrong input and imported to index db)
![image](https://user-images.githubusercontent.com/16869603/146844880-4c7ea916-b0b5-4840-89f5-4c73b8ef4d21.png)
    - Test:  search BRAF V600E
- Fix `delins` validator. https://github.com/genome-nexus/genome-nexus/issues/559
    - Test: search 9:g.21971036delinsTT
- Disable mutation assessor for now because it's too slow recently