### PR TITLE
Fix dup validation

### DIFF
--- a/src/page/Home.tsx
+++ b/src/page/Home.tsx
@@ -8,9 +8,7 @@ import './Home.scss';
 import logo from '../image/home_page_logo.png';
 import { isVariantValid } from '../util/variantValidator';
 import client from './genomeNexusClientInstance';
-import ValidatorNotification, {
-    ErrorType,
-} from '../component/ValidatorNotification';
+import { ErrorType } from '../component/ValidatorNotification';
 import { Link } from 'react-router-dom';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
 
@@ -272,11 +270,6 @@ class Home extends React.Component<{ history: any }> {
                             {searchExample}
                         </Col>
                     </Row>
-                    <ValidatorNotification
-                        showAlert={this.alert}
-                        type={this.alertType}
-                        onClose={this.onClose}
-                    />
                 </div>
             </div>
         );

--- a/src/util/variantValidator.tsx
+++ b/src/util/variantValidator.tsx
@@ -87,7 +87,7 @@ export function isVariantValid(variant: string): VariantValidStatus {
         // DUP
         else if (variant.includes(VARIANT_OPERATOR.DUP)) {
             pattern =
-                /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*_[0-9]*(dup)$/i;
+                /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*(?:_([0-9]*))?(dup)$/i;
             if (variant.trim().match(pattern)) {
                 return {
                     isValid: true,


### PR DESCRIPTION
Fix https://github.com/genome-nexus/genome-nexus/issues/581
- [x] when a hgvsg is found in db, no need to validate, ie always to the variant page
    - I'm thinking maybe it makes sense to remove validation. Our design for searching hgvsg is: whatever the input is, we directly show it in dropdown, so when users search a new variant they don't have to click "show more" to get options. In this case we never check if this hgvsg is in db, so probably ok to remove validation.
- [x] fix validation for dup

