### PR TITLE
Specify reference genome for oncokb calls

### DIFF
--- a/src/page/Main.tsx
+++ b/src/page/Main.tsx
@@ -11,9 +11,11 @@ import Api from './Api';
 import { VariantStore } from './VariantStore';
 import { observer } from 'mobx-react';
 import News from './News';
+import { MainStore } from './MainStore';
 
 @observer
 class Main extends React.Component<{}> {
+    private mainStore = new MainStore();
     public render() {
         const VariantPage = (props: any) => (
             <Variant
@@ -21,10 +23,14 @@ class Main extends React.Component<{}> {
                 store={
                     new VariantStore(
                         props.match.params.variant,
-                        props.location.search
+                        props.location.search,
+                        this.mainStore
                     )
                 }
             />
+        );
+        const HomePage = (props: any) => (
+            <Home history={props.history} mainStore={this.mainStore} />
         );
 
         return (
@@ -33,7 +39,7 @@ class Main extends React.Component<{}> {
                     <Header />
                     <div>
                         <Switch>
-                            <Route exact={true} path="/" component={Home} />
+                            <Route exact={true} path="/" component={HomePage} />
                             <Route
                                 exact={true}
                                 path="/variant/:variant"

--- a/src/page/MainStore.ts
+++ b/src/page/MainStore.ts
@@ -1,0 +1,19 @@
+import { remoteData } from 'cbioportal-frontend-commons';
+import MobxPromise from 'mobxpromise';
+import { GENOME_BUILD } from '../util/SearchUtils';
+import client from './genomeNexusClientInstance';
+
+export class MainStore {
+    readonly genomeBuild: MobxPromise<string> = remoteData({
+        invoke: async () => {
+            const variantAnnotation = await client.fetchVariantAnnotationGET({
+                variant: '17:g.41242962_41242963insGA',
+            });
+            // default genome build is grch37
+            return variantAnnotation?.assembly_name || GENOME_BUILD.GRCh37;
+        },
+        onError: () => {
+            // fail silently, leave the error handling responsibility to the data consumer
+        },
+    });
+}

--- a/src/page/VariantStore.ts
+++ b/src/page/VariantStore.ts
@@ -24,13 +24,18 @@ import {
 } from 'react-mutation-mapper';
 import { annotationQueryFields } from '../config/configDefaults';
 import { getTranscriptConsequenceSummary } from '../util/AnnotationSummaryUtil';
+import { MainStore } from './MainStore';
 
 export interface VariantStoreConfig {
     variant: string;
 }
 export class VariantStore {
     public query: any;
-    constructor(public variantId: string, public queryString: string) {
+    constructor(
+        public variantId: string,
+        public queryString: string,
+        public mainStore: MainStore
+    ) {
         makeObservable(this);
         this.variant = variantId;
         this.query = qs.parse(this.queryString, { ignoreQueryPrefix: true });
@@ -112,9 +117,11 @@ export class VariantStore {
     });
 
     readonly oncokbData: MobxPromise<IndicatorQueryResp> = remoteData({
+        await: () => [this.mainStore.genomeBuild],
         invoke: async () => {
             return await oncokbClient.annotateMutationsByHGVSgGetUsingGET_1({
                 hgvsg: this.variant,
+                referenceGenome: this.mainStore.genomeBuild.result || undefined,
             });
         },
         onError: () => {

--- a/src/util/SearchUtils.ts
+++ b/src/util/SearchUtils.ts
@@ -29,10 +29,14 @@ export const SEARCH_BAR_EXAMPLE_DATA_GRCh38 = [
         link: '/variant/7:g.55181378C>T',
         label: 'EGFR:p.T790M',
     },
-    // 1 Search bar example
+    // 1 Search bar example (BRAF V600E, add this back after fixing grch38 canonical transcript mapping)
+    // {
+    //     link: '/variant/7:g.140753336A>T',
+    //     label: '7:g.140753336A>T',
+    // },
     {
-        link: '/variant/7:g.140753336A>T',
-        label: '7:g.140753336A>T',
+        link: '/variant/17:g.43124027A>T',
+        label: '17:g.43124027A>T',
     },
     // 2 Search bar example
     {


### PR DESCRIPTION
Part of: https://github.com/genome-nexus/genome-nexus/issues/591
Temp fix for oncokb calls. For grch38 instances we need to add `referenceGenome=GRCh38` when calling onockb.
Also replace `BRAF V600E` example on grch38 home page to 17:g.43124027A>T BRCA1 p.C24S
![Feb-17-2022 17-54-55](https://user-images.githubusercontent.com/16869603/154585428-96c84693-a8aa-43b8-bb6d-e133e03528c6.gif)

