### PR TITLE
Add reVUE revised effect for one KIT variant

### DIFF
--- a/src/component/variantPage/BiologicalFunction.tsx
+++ b/src/component/variantPage/BiologicalFunction.tsx
@@ -7,23 +7,18 @@ import { IndicatorQueryResp } from 'oncokb-ts-api-client';
 import Separator from '../Separator';
 import Oncokb from './biologicalFunction/Oncokb';
 import ClinvarInterpretation from './biologicalFunction/ClinvarInterpretation';
-import CuriousCase from './biologicalFunction/CuriousCase';
-import { CuriousCases } from 'genome-nexus-ts-api-client/dist/generated/GenomeNexusAPIInternal';
+import CuriousCase, { VUE } from './biologicalFunction/CuriousCase';
 
 interface IBiologicalFunctionProps {
     oncokb: IndicatorQueryResp | undefined;
     isCanonicalTranscriptSelected: boolean;
     clinvar?: Clinvar;
-    curiousCases?: CuriousCases;
+    curiousCases?: VUE;
 }
 
 @observer
 class BiologicalFunction extends React.Component<IBiologicalFunctionProps> {
     public render() {
-        // only show curious case when URL has "curious"
-        const showCuriousCase =
-            window.location.search.split('curious').length > 1 ? true : false;
-
         return (
             <>
                 <Oncokb
@@ -39,12 +34,8 @@ class BiologicalFunction extends React.Component<IBiologicalFunctionProps> {
                         this.props.isCanonicalTranscriptSelected
                     }
                 />
-                {showCuriousCase && (
-                    <>
-                        <Separator />
-                        <CuriousCase curiousCases={this.props.curiousCases} />
-                    </>
-                )}
+                <Separator />
+                <CuriousCase curiousCases={this.props.curiousCases} />
             </>
         );
     }

--- a/src/component/variantPage/FunctionalGroups.tsx
+++ b/src/component/variantPage/FunctionalGroups.tsx
@@ -16,7 +16,7 @@ import functionalGroupsStyle from './functionalGroups.module.scss';
 import ClinicalImplication from './ClinicalImplication';
 import { RemoteData } from 'cbioportal-utils';
 import PrevalenceInCancer from './PrevalenceInCancer';
-import { CuriousCases } from 'genome-nexus-ts-api-client/dist/generated/GenomeNexusAPIInternal';
+import { VUE } from './biologicalFunction/CuriousCase';
 
 interface IFunctionalGroupsProps {
     annotationInternal?: VariantAnnotationSummary;
@@ -28,8 +28,8 @@ interface IFunctionalGroupsProps {
     indexAnnotationsByGenomicLocationPromise: RemoteData<{
         [genomicLocation: string]: VariantAnnotation;
     }>;
-    curiousCases?: CuriousCases;
     genomeBuild?: string;
+    curiousCases?: VUE;
 }
 
 @observer

--- a/src/component/variantPage/biologicalFunction/CuriousCase.tsx
+++ b/src/component/variantPage/biologicalFunction/CuriousCase.tsx
@@ -1,43 +1,31 @@
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
-import { CuriousCases } from 'genome-nexus-ts-api-client/dist/generated/GenomeNexusAPIInternal';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import functionalGroupsStyle from '../functionalGroups.module.scss';
 
-interface ICuriousCaseProps {
-    curiousCases?: CuriousCases;
-}
-
-const TooltipLinks: React.FunctionComponent<{ pubmedIds: number[] }> = (
-    props
-) => {
-    let tooltipLinks: JSX.Element[] = [];
-    props.pubmedIds.forEach((id) => {
-        tooltipLinks.push(
-            <a
-                href={`https://pubmed.ncbi.nlm.nih.gov/${id}/`}
-                target="_blank"
-                rel="noopener noreferrer"
-            >
-                {id}
-                {`;  `}
-            </a>
-        );
-    });
-    return <>{tooltipLinks}</>;
+export declare type VUE = {
+    'comment': string;
+    'context': string;
+    'referenceText': string;
+    'pubmedIds': Array<number>;
+    'revisedProteinEffects': Array<{
+        'revisedProteinEffect': string;  
+        'variantClassification': string;
+        'variant': string;
+    }>
 };
 
+interface ICuriousCaseProps {
+    curiousCases?: VUE;
+}
+
 const CuriousCaseContent: React.FunctionComponent<{
-    curiousCases?: CuriousCases;
+    curiousCases?: VUE;
 }> = (props) => {
     return props.curiousCases ? (
         <span>
-            {props.curiousCases.comment} {`. Pubmed ids: `}
-            {props.curiousCases.pubmedIds ? (
-                <TooltipLinks pubmedIds={props.curiousCases.pubmedIds} />
-            ) : (
-                'NA'
-            )}
+            {props.curiousCases.comment}{' '}
+            <a href={`https://pubmed.ncbi.nlm.nih.gov/${props.curiousCases.pubmedIds[0]}/`} rel="noopener noreferrer" target="_blank">({props.curiousCases.referenceText})</a>
         </span>
     ) : (
         <span>NA</span>
@@ -52,13 +40,9 @@ export default class CuriousCase extends React.Component<ICuriousCaseProps> {
                 <div className={functionalGroupsStyle['data-source']}>
                     <DefaultTooltip
                         placement="top"
-                        overlay={<div>Curated list of splice variants.</div>}
+                        overlay={<div>Repository of Variants with Unexpected Effects</div>}
                     >
-                        <span
-                            className={functionalGroupsStyle['without-linkout']}
-                        >
-                            Curious Case
-                        </span>
+                        <a href={'https://www.cancerrevue.org/'}>reVUE <i className="fa fa-external-link" /></a>
                     </DefaultTooltip>
                 </div>
                 <CuriousCaseContent curiousCases={this.props.curiousCases} />

--- a/src/data/VUEs.json
+++ b/src/data/VUEs.json
@@ -1,0 +1,86 @@
+[
+    {
+        "hugoGeneSymbol": "APC",
+        "genomicLocation": "5:g.112151184A>G",
+        "defaultEffect": "synonymous",
+        "comment": "Introduces splice acceptor site causing a frameshift",
+        "pubmedIds": [29316426],
+        "context": "Recurrent alteration in CRC",
+        "referenceText": "Yaeger et al, 2018"
+    },
+    {
+        "hugoGeneSymbol": "BAP1",
+        "genomicLocation": "3:g.52439306A>G",
+        "defaultEffect": "synonymous",
+        "comment": "Leads to exon 11 skipping",
+        "context": "Recurrent and prognostic in kidney cancer",
+        "pubmedIds": [33681728],
+        "referenceText": "Niersch et al, 2021"
+    },
+    {
+        "genomicLocation": "17:g.7579883G>A",
+        "defaultEffect": "synonymous",
+        "comment": "Affects mRNA structure, reduces HDM2 binding",
+        "context": "Recurrent in many cancer types",
+        "pubmedIds": [31671760],
+        "hugoGeneSymbol": "TP53",
+        "referenceText": "Swiatkowska et al, 2019"
+    },
+    {
+        "genomicLocation": "12:g.25380277G>T",
+        "defaultEffect": "missense",
+        "comment": "Introduces a splice donor site if Q61K is not co-occurring with G60G",
+        "context": "Recurrent in many cancer types",
+        "pubmedIds": [35236983],
+        "hugoGeneSymbol": "KRAS",
+        "referenceText": "Kobayashi et al, 2022"
+    },
+    {
+        "hugoGeneSymbol": "CTNNB1",
+        "genomicLocation": "Deletions flanking exon 2-3 (chr3:41265579_41266277del)",
+        "defaultEffect": "splice",
+        "comment": "Complete exon 3 skip or inframe deletion in exon 3",
+        "pubmedIds": [29316426],
+        "context": "Recurrent alteration in CRC",
+        "referenceText": "Yaeger et al, 2018"
+    },
+    {
+        "hugoGeneSymbol": "KIT",
+        "genomicLocation": "Deletions flanking intron 10 - exon 11 boundary (4:55593576_55593606del)",
+        "defaultEffect": "splice",
+        "comment": "Changes splice donor site, cause inframe deletion in exon 11",
+        "context": "Actionable in GIST",
+        "pubmedIds": [15507676],
+        "referenceText": "Corless et al, 2004",
+        "revisedProteinEffects": [
+            {"variant":"4:g.55593576_55593606del", "transcriptId": "ENST00000288135", "revisedProteinEffect": "p.549_557del", "variantClassification":"In frame deletion"}
+        ]
+    },
+    {
+        "hugoGeneSymbol": "MET",
+        "genomicLocation": "Indels and substitutions flanking exon 14 (7:116411926_116412083del)",
+        "defaultEffect": "splice",
+        "comment": "Skipping of exon 14",
+        "context": "Actionable in NSCLC",
+        "pubmedIds": [27343443],
+        "referenceText": "Schrock et al, 2014"
+    },
+    {
+        "hugoGeneSymbol": "PIK3R1",
+        "genomicLocation": "Indels and substitutions flanking exon 11 (5:67589663G>A)",
+        "defaultEffect": "splice",
+        "comment": "Skipping of exon 11",
+        "context": "Recurrent in breast and uterine cancer",
+        "pubmedIds": [25488983],
+        "referenceText": "Lucas et al, 2014"
+    },
+    {
+        "hugoGeneSymbol": "FLT3",
+        "genomicLocation": "Indels around tyrosine kinase (13:28608214_28608215insTT...)",
+        "defaultEffect": "splice",
+        "comment": "Internal Tandem Duplication",
+        "context": "Recurrent alteration in AML",
+        "pubmedIds": [25488983],
+        "referenceText": "Zhang et al, 2020"
+    }
+]

--- a/src/page/Variant.tsx
+++ b/src/page/Variant.tsx
@@ -391,6 +391,7 @@ class Variant extends React.Component<IVariantProps> {
                                                     transcriptId
                                                 )
                                             }
+                                            vue={this.props.store.vue.result}
                                         />
                                     </Col>
                                 </Row>
@@ -470,12 +471,10 @@ class Variant extends React.Component<IVariantProps> {
                                             ]: VariantAnnotation;
                                         }>
                                     }
-                                    curiousCases={
-                                        this.props.store.curiousCases.result
-                                    }
                                     genomeBuild={
                                         this.props.store.genomeBuild.result
                                     }
+                                    curiousCases={this.props.store.vue.result}
                                 />
                             </Col>
                         </Row>


### PR DESCRIPTION
This uses some of the old "curious cases" infrastructure but replaces it by directly using the VUE data from the revue-website repo. This still needs to be fully refactored to lose all references to "curious cases".