### PR TITLE
Fix bug when no transcript available

### DIFF
--- a/src/util/variantUtils.ts
+++ b/src/util/variantUtils.ts
@@ -63,6 +63,6 @@ export function isVue(
             (summary) => summary.transcriptId === selectedTranscript
         )?.isVue;
     } else {
-        return annotation?.transcriptConsequenceSummary.isVue;
+        return annotation?.transcriptConsequenceSummary?.isVue;
     }
 }


### PR DESCRIPTION
The page crashes for `2:g.159740254C>A` because no transcript is available for this variant.