### PR TITLE
Fix for Intergenic Variants

### DIFF
--- a/src/component/variantPage/BasicInfo.tsx
+++ b/src/component/variantPage/BasicInfo.tsx
@@ -24,6 +24,7 @@ import { ReVUEContent } from './biologicalFunction/ReVUE';
 import { isVue } from '../../util/variantUtils';
 
 interface IBasicInfoProps {
+    isIGV: boolean;
     annotation: VariantAnnotationSummary | undefined;
     mutation: Mutation;
     variant: string;
@@ -146,12 +147,27 @@ export default class BasicInfo extends React.Component<IBasicInfoProps> {
                     selectedTranscript || canonicalTranscript,
                     this.props.variant
                 );
-            if (renderData === null) {
-                return null;
-            }
             if (renderData) {
                 renderData = renderData.filter((data) => data.value != null); // remove null fields
             }
+
+            if (renderData === null) {
+                if (this.props.isIGV) {
+                    renderData = [
+                        {
+                            value: 'Intergenic Variant',
+                            key: 'variantType',
+                            category: 'mutation',
+                        },
+                        {
+                            value: this.props.variant,
+                            key: 'hgvsg',
+                            category: 'hgvsg',
+                        },
+                    ];
+                } else return null;
+            }
+
             // if variant is VUE, remove hgvsShort and variantClassification
             // Show revised hgvsShort and variantClassification in VUE block instead
             // Otherwise show all fields
@@ -175,14 +191,22 @@ export default class BasicInfo extends React.Component<IBasicInfoProps> {
                 'transcript',
                 'refSeq',
             ];
-
+            const keysForIGV = ['variantType', 'hgvsg'];
             return (
                 <div className={basicInfo['basic-info-container']}>
                     <span className={basicInfo['basic-info-pills']}>
-                        {this.getPillList(keysBeforeVue, renderData)}
-                        {showVue &&
-                            this.generateBasicInfoReVUE(this.props.annotation)}
-                        {this.getPillList(keysAfterVue, renderData)}
+                        {this.props.isIGV &&
+                            this.getPillList(keysForIGV, renderData)}
+                        {!this.props.isIGV && (
+                            <>
+                                {this.getPillList(keysBeforeVue, renderData)}
+                                {showVue &&
+                                    this.generateBasicInfoReVUE(
+                                        this.props.annotation
+                                    )}
+                                {this.getPillList(keysAfterVue, renderData)}
+                            </>
+                        )}
                         {this.jsonButton()}
                         {haveTranscriptTable &&
                             this.transcriptsButton(this.showAllTranscripts)}

--- a/src/page/Variant.tsx
+++ b/src/page/Variant.tsx
@@ -357,6 +357,13 @@ class Variant extends React.Component<IVariantProps> {
                                 <Row>
                                     <Col>
                                         <BasicInfo
+                                            isIGV={
+                                                this.props.store.annotation
+                                                    .result
+                                                    ?.most_severe_consequence ===
+                                                    'intergenic_variant' ||
+                                                false
+                                            }
                                             annotation={
                                                 this.props.store
                                                     .annotationSummary

--- a/src/util/SearchUtils.ts
+++ b/src/util/SearchUtils.ts
@@ -250,7 +250,9 @@ export function normalizeSearchText(keyword: string) {
         }
         // Check if the firstPart matches the pattern ^(chr)?([1-9]|1[0-9]|2[0-4]|[XY]|(MT))
         // If firstPart matches the pattern, keep it lowercase, otherwise uppercase it
-        const firstPartProcessed = /^\b(chr)/.test(firstPart)? firstPart : _.toUpper(firstPart);
+        const firstPartProcessed = /^\b(chr)/.test(firstPart)
+            ? firstPart
+            : _.toUpper(firstPart);
 
         // if "del"/"ins"/"dup" in text(it should be in second part of text after splitting by ":"), don't convert second part to upper case
         // otherwire convert all to upper case except type

--- a/src/util/SearchUtils.ts
+++ b/src/util/SearchUtils.ts
@@ -248,6 +248,10 @@ export function normalizeSearchText(keyword: string) {
             secondPart = keyword.slice(seperatorIndex + 3, keyword.length);
             type = keyword.slice(seperatorIndex + 1, seperatorIndex + 3);
         }
+        // Check if the firstPart matches the pattern ^(chr)?([1-9]|1[0-9]|2[0-4]|[XY]|(MT))
+        // If firstPart matches the pattern, keep it lowercase, otherwise uppercase it
+        const firstPartProcessed = /^\b(chr)/.test(firstPart)? firstPart : _.toUpper(firstPart);
+
         // if "del"/"ins"/"dup" in text(it should be in second part of text after splitting by ":"), don't convert second part to upper case
         // otherwire convert all to upper case except type
         const match = secondPart.match(/del|dup|ins/g);
@@ -255,7 +259,7 @@ export function normalizeSearchText(keyword: string) {
             const alternationType = match[0];
             const location = secondPart.split(alternationType)[0];
             const alleles = secondPart.split(alternationType)[1];
-            keyword = `${_.toUpper(firstPart)}${separator}${type}${_.toUpper(
+            keyword = `${firstPartProcessed}${separator}${type}${_.toUpper(
                 location
             )}${alternationType}${_.toUpper(alleles)}`;
         }
@@ -264,11 +268,11 @@ export function normalizeSearchText(keyword: string) {
             const alternationType = 'delins';
             const location = secondPart.split(alternationType)[0];
             const alleles = secondPart.split(alternationType)[1];
-            keyword = `${_.toUpper(firstPart)}${separator}${type}${_.toUpper(
+            keyword = `${firstPartProcessed}${separator}${type}${_.toUpper(
                 location
             )}${alternationType}${_.toUpper(alleles)}`;
         } else {
-            keyword = `${_.toUpper(firstPart)}${separator}${type}${_.toUpper(
+            keyword = `${firstPartProcessed}${separator}${type}${_.toUpper(
                 secondPart
             )}`;
         }

--- a/src/util/variantValidator.tsx
+++ b/src/util/variantValidator.tsx
@@ -37,7 +37,7 @@ export function isVariantValid(variant: string): VariantValidStatus {
         if (variant.includes(VARIANT_OPERATOR.SNP)) {
             // chromosome(1-24,X,Y,MT) + start(number) + ref(A/T/G/C) + ">" + var(A/T/G/C)
             pattern =
-                /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*[ATGC]>[ATGC]$/i;
+                /^\b(chr[1-9]|chr1[0-9]|chr2[0-4]|chr[XY]|(chrMT)|[1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*[ATGC]>[ATGC]$/i;
             if (variant.trim().match(pattern)) {
                 return {
                     isValid: true,
@@ -50,7 +50,7 @@ export function isVariantValid(variant: string): VariantValidStatus {
         else if (variant.includes(VARIANT_OPERATOR.DELINS)) {
             // chromosome(1-24,X,Y,MT) + start(number) + "_" + end(number) + "delins" + var(ATGC)
             pattern =
-                /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*(?:_([0-9]*))?(delins)[ATGC]*$/i;
+                /^\b(chr[1-9]|chr1[0-9]|chr2[0-4]|chr[XY]|(chrMT)|[1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*(?:_([0-9]*))?(delins)[ATGC]*$/i;
             if (variant.trim().match(pattern)) {
                 return {
                     isValid: true,
@@ -63,7 +63,7 @@ export function isVariantValid(variant: string): VariantValidStatus {
         else if (variant.includes(VARIANT_OPERATOR.INS)) {
             // chromosome(1-24,X,Y,MT) + start(number) + "_" + end(number) + "ins" + var(ATGC)
             pattern =
-                /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*_[0-9]*(ins)[ATGC]*$/i;
+                /^\b(chr[1-9]|chr1[0-9]|chr2[0-4]|chr[XY]|(chrMT)|[1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*_[0-9]*(ins)[ATGC]*$/i;
             if (variant.trim().match(pattern)) {
                 return {
                     isValid: true,
@@ -75,7 +75,7 @@ export function isVariantValid(variant: string): VariantValidStatus {
         // DEL
         else if (variant.includes(VARIANT_OPERATOR.DEL)) {
             pattern =
-                /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*(?:_([0-9]*))?(del)$/i;
+                /^\b(chr[1-9]|chr1[0-9]|chr2[0-4]|chr[XY]|(chrMT)|[1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*(?:_([0-9]*))?(del)$/i;
             if (variant.trim().match(pattern)) {
                 return {
                     isValid: true,
@@ -87,7 +87,7 @@ export function isVariantValid(variant: string): VariantValidStatus {
         // DUP
         else if (variant.includes(VARIANT_OPERATOR.DUP)) {
             pattern =
-                /^\b([1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*(?:_([0-9]*))?(dup)$/i;
+                /^\b(chr[1-9]|chr1[0-9]|chr2[0-4]|chr[XY]|(chrMT)|[1-9]|1[0-9]|2[0-4]|[XY]|(MT))\b(:g.)[0-9]*(?:_([0-9]*))?(dup)$/i;
             if (variant.trim().match(pattern)) {
                 return {
                     isValid: true,


### PR DESCRIPTION
Fix for genom-nexus/genome-nexus-frontend#734
This pr fixes the results shown for intergenic variants. 
1) Instead of Lollipop plot, a "No plot" component is rendered.
2) Basic information like variantType, hgsv, json, etc. is displayed using pills.
