### PR TITLE
Fix for intergenic variant

### DIFF
--- a/src/component/variantPage/BasicInfo.tsx
+++ b/src/component/variantPage/BasicInfo.tsx
@@ -24,6 +24,7 @@ import { ReVUEContent } from './biologicalFunction/ReVUE';
 import { isVue } from '../../util/variantUtils';
 
 interface IBasicInfoProps {
+    isIGV: boolean;
     annotation: VariantAnnotationSummary | undefined;
     mutation: Mutation;
     variant: string;
@@ -146,12 +147,27 @@ export default class BasicInfo extends React.Component<IBasicInfoProps> {
                     selectedTranscript || canonicalTranscript,
                     this.props.variant
                 );
-            if (renderData === null) {
-                return null;
-            }
             if (renderData) {
                 renderData = renderData.filter((data) => data.value != null); // remove null fields
             }
+
+            if (renderData === null) {
+                if (this.props.isIGV) {
+                    renderData = [
+                        {
+                            value: 'Intergenic Variant',
+                            key: 'variantType',
+                            category: 'mutation',
+                        },
+                        {
+                            value: this.props.variant,
+                            key: 'hgvsg',
+                            category: 'hgvsg',
+                        },
+                    ];
+                } else return null;
+            }
+
             // if variant is VUE, remove hgvsShort and variantClassification
             // Show revised hgvsShort and variantClassification in VUE block instead
             // Otherwise show all fields
@@ -175,14 +191,22 @@ export default class BasicInfo extends React.Component<IBasicInfoProps> {
                 'transcript',
                 'refSeq',
             ];
-
+            const keysForIGV = ['variantType', 'hgvsg'];
             return (
                 <div className={basicInfo['basic-info-container']}>
                     <span className={basicInfo['basic-info-pills']}>
-                        {this.getPillList(keysBeforeVue, renderData)}
-                        {showVue &&
-                            this.generateBasicInfoReVUE(this.props.annotation)}
-                        {this.getPillList(keysAfterVue, renderData)}
+                        {this.props.isIGV &&
+                            this.getPillList(keysForIGV, renderData)}
+                        {!this.props.isIGV && (
+                            <>
+                                {this.getPillList(keysBeforeVue, renderData)}
+                                {showVue &&
+                                    this.generateBasicInfoReVUE(
+                                        this.props.annotation
+                                    )}
+                                {this.getPillList(keysAfterVue, renderData)}
+                            </>
+                        )}
                         {this.jsonButton()}
                         {haveTranscriptTable &&
                             this.transcriptsButton(this.showAllTranscripts)}

--- a/src/page/Variant.tsx
+++ b/src/page/Variant.tsx
@@ -357,6 +357,13 @@ class Variant extends React.Component<IVariantProps> {
                                 <Row>
                                     <Col>
                                         <BasicInfo
+                                            isIGV={
+                                                this.props.store.annotation
+                                                    .result
+                                                    ?.most_severe_consequence ===
+                                                    'intergenic_variant' ||
+                                                false
+                                            }
                                             annotation={
                                                 this.props.store
                                                     .annotationSummary


### PR DESCRIPTION
Fixes https://github.com/genome-nexus/genome-nexus/issues/734
Fixes https://github.com/genome-nexus/genome-nexus/issues/721
This pr fixes the results shown for intergenic variants.
1) Instead of Lollipop plot, a "No plot" component is rendered. 
2) Basic information like variantType, hgsv, json, etc. is displayed using pills.