### PR TITLE
Update packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "@types/superagent": "^4.1.1",
     "autobind-decorator": "^2.4.0",
     "bootstrap": "^4.3.1",
-    "cbioportal-frontend-commons": "^0.5.51",
-    "cbioportal-utils": "^0.3.34",
+    "cbioportal-frontend-commons": "^0.5.67",
+    "cbioportal-utils": "^0.3.41",
     "classnames": "^2.2.6",
     "file-loader": "^4.3.0",
     "font-awesome": "^4.7.0",
-    "genome-nexus-ts-api-client": "^1.1.28",
+    "genome-nexus-ts-api-client": "1.1.32",
     "lodash": "^4.17.21",
     "mobx": "^6.0.0",
     "mobx-react": "^6.0.0",
@@ -42,7 +42,7 @@
     "react-bootstrap": "^1.0.0-beta.6",
     "react-dom": "^16.14.0",
     "react-markdown": "^7.0.1",
-    "react-mutation-mapper": "^0.8.93",
+    "react-mutation-mapper": "^0.8.110",
     "react-router-bootstrap": "^0.24.4",
     "react-router-dom": "^4.3.1",
     "react-scripts": "^3.4.4",
@@ -85,5 +85,9 @@
   },
   "devDependencies": {
     "@types/react-scroll": "^1.5.4"
+  },
+  "resolutions": {
+    "cheerio": "1.0.0-rc.10",
+    "parse5-htmlparser2-tree-adapter": "^6.0.0"
   }
 }

--- a/src/component/variantPage/BasicInfo.tsx
+++ b/src/component/variantPage/BasicInfo.tsx
@@ -437,7 +437,7 @@ export default class BasicInfo extends React.Component<IBasicInfoProps> {
                         >
                             {
                                 annotationSummary.vues
-                                    .revisedVariantClassification
+                                    .revisedVariantClassificationStandard
                             }
                         </span>
                     </a>

--- a/src/component/variantPage/ClinicalImplication.tsx
+++ b/src/component/variantPage/ClinicalImplication.tsx
@@ -1,30 +1,30 @@
-import _ from 'lodash';
+// import _ from 'lodash';
 import * as React from 'react';
 import { observer } from 'mobx-react';
 
 import { IndicatorQueryResp } from 'oncokb-ts-api-client';
-import { ICivicVariantIndex, ICivicVariantSummary } from 'cbioportal-utils';
+// import { ICivicVariantIndex, ICivicVariantSummary } from 'cbioportal-utils';
 
 import OncoKb from './clinicalImplication/OncoKb';
-import Civic from './clinicalImplication/Civic';
-import Separator from '../Separator';
+// import Civic from './clinicalImplication/Civic';
+// import Separator from '../Separator';
 
 interface IClinicalImplicationProps {
     oncokb: IndicatorQueryResp | undefined;
-    civic?: ICivicVariantIndex;
+    // civic?: ICivicVariantIndex;
     isCanonicalTranscriptSelected: boolean;
 }
 
 @observer
 class ClinicalImplication extends React.Component<IClinicalImplicationProps> {
-    get civicVariant(): ICivicVariantSummary | undefined {
-        if (this.props.civic) {
-            // assuming the index only contains one variant
-            return _.values(_.values(this.props.civic)[0])[0];
-        } else {
-            return undefined;
-        }
-    }
+    // get civicVariant(): ICivicVariantSummary | undefined {
+    //     if (this.props.civic) {
+    //         // assuming the index only contains one variant
+    //         return _.values(_.values(this.props.civic)[0])[0];
+    //     } else {
+    //         return undefined;
+    //     }
+    // }
 
     public render() {
         return (
@@ -35,13 +35,13 @@ class ClinicalImplication extends React.Component<IClinicalImplicationProps> {
                         this.props.isCanonicalTranscriptSelected
                     }
                 />
-                <Separator />
-                <Civic
+                {/* <Separator /> */}
+                {/* <Civic
                     civic={this.civicVariant}
                     isCanonicalTranscriptSelected={
                         this.props.isCanonicalTranscriptSelected
                     }
-                />
+                /> */}
             </>
         );
     }

--- a/src/component/variantPage/FunctionalGroups.tsx
+++ b/src/component/variantPage/FunctionalGroups.tsx
@@ -50,7 +50,7 @@ class FunctionalGroups extends React.Component<IFunctionalGroupsProps> {
                         <td>
                             <ClinicalImplication
                                 oncokb={this.props.oncokb}
-                                civic={this.props.civic}
+                                // civic={this.props.civic}
                                 isCanonicalTranscriptSelected={
                                     this.props.isCanonicalTranscriptSelected
                                 }

--- a/src/component/variantPage/biologicalFunction/ReVUE.tsx
+++ b/src/component/variantPage/biologicalFunction/ReVUE.tsx
@@ -12,41 +12,42 @@ export const ReVUEContent: React.FunctionComponent<IReVUEProps> = (props) => {
     return props.vue ? (
         <div>
             <div>
-                Predicted Effect by{` `}
-                {
-                    <a
-                        href="https://useast.ensembl.org/info/docs/tools/vep/index.html"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        VEP
-                    </a>
-                }
+                Predicted Effect by{' '}
+                <a
+                    href="https://useast.ensembl.org/info/docs/tools/vep/index.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    VEP
+                </a>
                 : <strong>{props.vue.defaultEffect}</strong>
             </div>
             <div>
-                Revised Protein Effect by{` `}
-                {
-                    <a
-                        href="https://cancerrevue.org"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        reVUE
-                    </a>
-                }
-                {` (`}
-                {
-                    <a
-                        href={`https://pubmed.ncbi.nlm.nih.gov/${props.vue.pubmedId}/`}
-                        rel="noopener noreferrer"
-                        target="_blank"
-                    >
-                        {props.vue.referenceText}
-                    </a>
-                }
-                {`): `}
-                <strong>{props.vue.revisedProteinEffect}</strong>
+                Revised Protein Effect by{' '}
+                <a
+                    href="https://cancerrevue.org"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    reVUE
+                </a>{' '}
+                (
+                {props.vue.references.map((reference, index) => (
+                    <React.Fragment key={reference.pubmedId}>
+                        {index > 0 && ', '}
+                        <a
+                            href={`https://pubmed.ncbi.nlm.nih.gov/${reference.pubmedId}/`}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                        >
+                            {reference.referenceText}
+                        </a>
+                    </React.Fragment>
+                ))}
+                ):{' '}
+                <strong>
+                    {props.vue.revisedVariantClassificationStandard}
+                </strong>
             </div>
         </div>
     ) : (

--- a/src/component/variantPage/clinicalImplication/Civic.tsx
+++ b/src/component/variantPage/clinicalImplication/Civic.tsx
@@ -1,112 +1,112 @@
-import { observer } from 'mobx-react';
+// import { observer } from 'mobx-react';
 import * as React from 'react';
 
-import { ICivicEvidenceSummary, ICivicVariantSummary } from 'cbioportal-utils';
-import { DefaultTooltip } from 'cbioportal-frontend-commons';
+// import { ICivicEvidenceSummary, ICivicVariantSummary } from 'cbioportal-utils';
+// import { DefaultTooltip } from 'cbioportal-frontend-commons';
 
-import {
-    ClinicalSignificance,
-    Evidence,
-    EvidenceType,
-} from '../../../util/EvidenceUtils';
-import EvidenceSummary from './EvidenceSummary';
-import functionalGroupsStyle from '../functionalGroups.module.scss';
+// import {
+//     ClinicalSignificance,
+//     Evidence,
+//     EvidenceType,
+// } from '../../../util/EvidenceUtils';
+// import EvidenceSummary from './EvidenceSummary';
+// import functionalGroupsStyle from '../functionalGroups.module.scss';
 
-interface ICivicProps {
-    civic?: ICivicVariantSummary;
-    isCanonicalTranscriptSelected: boolean;
-}
+// interface ICivicProps {
+//     civic?: ICivicVariantSummary;
+//     isCanonicalTranscriptSelected: boolean;
+// }
 
-const DEFAULT_CIVIC_URL = 'https://civicdb.org/';
+// const DEFAULT_CIVIC_URL = 'https://civicdb.org/';
 
-function getEvidenceUrl(civic: ICivicVariantSummary, evidenceId: number) {
-    return `https://civicdb.org/events/genes/${civic.geneId}/summary/variants/${civic.id}/summary/evidence/${evidenceId}/summary#evidence`;
-}
+// function getEvidenceUrl(civic: ICivicVariantSummary, evidenceId: number) {
+//     return `https://civicdb.org/events/genes/${civic.geneId}/summary/variants/${civic.id}/summary/evidence/${evidenceId}/summary#evidence`;
+// }
 
-const CivicInfo: React.FunctionComponent<{
-    url: string;
-    isCanonicalTranscriptSelected: boolean;
-}> = (props) => {
-    return (
-        <DefaultTooltip
-            placement="top"
-            overlay={
-                <div style={{ maxWidth: 350 }}>
-                    <a
-                        href={props.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        CIViC
-                    </a>{' '}
-                    is a community-edited forum for discussion and
-                    interpretation of peer-reviewed publications pertaining to
-                    the clinical relevance of variants (or biomarker
-                    alterations) in cancer.
-                </div>
-            }
-        >
-            <a href={props.url} target="_blank" rel="noopener noreferrer">
-                CIViC <i className="fas fa-external-link-alt" />
-                {!props.isCanonicalTranscriptSelected && `*`}
-            </a>
-        </DefaultTooltip>
-    );
-};
+// const CivicInfo: React.FunctionComponent<{
+//     url: string;
+//     isCanonicalTranscriptSelected: boolean;
+// }> = (props) => {
+//     return (
+//         <DefaultTooltip
+//             placement="top"
+//             overlay={
+//                 <div style={{ maxWidth: 350 }}>
+//                     <a
+//                         href={props.url}
+//                         target="_blank"
+//                         rel="noopener noreferrer"
+//                     >
+//                         CIViC
+//                     </a>{' '}
+//                     is a community-edited forum for discussion and
+//                     interpretation of peer-reviewed publications pertaining to
+//                     the clinical relevance of variants (or biomarker
+//                     alterations) in cancer.
+//                 </div>
+//             }
+//         >
+//             <a href={props.url} target="_blank" rel="noopener noreferrer">
+//                 CIViC <i className="fas fa-external-link-alt" />
+//                 {!props.isCanonicalTranscriptSelected && `*`}
+//             </a>
+//         </DefaultTooltip>
+//     );
+// };
 
-function civicEvidenceToEvidence(
-    civicEvidence: ICivicEvidenceSummary
-): Evidence {
-    return {
-        ...civicEvidence,
-        clinicalSignificance: civicEvidence.clinicalSignificance.includes(
-            ClinicalSignificance.Sensitivity
-        )
-            ? ClinicalSignificance.Sensitivity
-            : civicEvidence.clinicalSignificance,
-    } as Evidence;
-}
+// function civicEvidenceToEvidence(
+//     civicEvidence: ICivicEvidenceSummary
+// ): Evidence {
+//     return {
+//         ...civicEvidence,
+//         clinicalSignificance: civicEvidence.clinicalSignificance.includes(
+//             ClinicalSignificance.Sensitivity
+//         )
+//             ? ClinicalSignificance.Sensitivity
+//             : civicEvidence.clinicalSignificance,
+//     } as Evidence;
+// }
 
-@observer
-export default class Civic extends React.Component<ICivicProps> {
-    get clinicalEvidences() {
-        return (
-            this.props.civic?.evidences
-                .map(civicEvidenceToEvidence)
-                .filter(
-                    (e) =>
-                        e.type === EvidenceType.Predictive ||
-                        e.type === EvidenceType.Prognostic ||
-                        e.type === EvidenceType.Diagnostic
-                ) || []
-        );
-    }
+// @observer
+// export default class Civic extends React.Component<ICivicProps> {
+//     get clinicalEvidences() {
+//         return (
+//             this.props.civic?.evidences
+//                 .map(civicEvidenceToEvidence)
+//                 .filter(
+//                     (e) =>
+//                         e.type === EvidenceType.Predictive ||
+//                         e.type === EvidenceType.Prognostic ||
+//                         e.type === EvidenceType.Diagnostic
+//                 ) || []
+//         );
+//     }
 
-    public render() {
-        const url = this.props.civic ? this.props.civic.url : DEFAULT_CIVIC_URL;
+//     public render() {
+//         const url = this.props.civic ? this.props.civic.url : DEFAULT_CIVIC_URL;
 
-        return (
-            <div className={functionalGroupsStyle['functional-group']}>
-                <div className={functionalGroupsStyle['data-source']}>
-                    <CivicInfo
-                        url={url}
-                        isCanonicalTranscriptSelected={
-                            this.props.isCanonicalTranscriptSelected
-                        }
-                    />
-                </div>
-                <EvidenceSummary
-                    url={url}
-                    evidences={this.clinicalEvidences}
-                    getEvidenceUrl={this.getEvidenceUrl}
-                />
-            </div>
-        );
-    }
+//         return (
+//             <div className={functionalGroupsStyle['functional-group']}>
+//                 <div className={functionalGroupsStyle['data-source']}>
+//                     <CivicInfo
+//                         url={url}
+//                         isCanonicalTranscriptSelected={
+//                             this.props.isCanonicalTranscriptSelected
+//                         }
+//                     />
+//                 </div>
+//                 <EvidenceSummary
+//                     url={url}
+//                     evidences={this.clinicalEvidences}
+//                     getEvidenceUrl={this.getEvidenceUrl}
+//                 />
+//             </div>
+//         );
+//     }
 
-    private getEvidenceUrl = (evidence: ICivicEvidenceSummary) => {
-        return this.props.civic
-            ? getEvidenceUrl(this.props.civic, evidence.id)
-            : DEFAULT_CIVIC_URL;
-    };
-}
+//     private getEvidenceUrl = (evidence: ICivicEvidenceSummary) => {
+//         return this.props.civic
+//             ? getEvidenceUrl(this.props.civic, evidence.id)
+//             : DEFAULT_CIVIC_URL;
+//     };
+// }

--- a/src/page/MainStore.ts
+++ b/src/page/MainStore.ts
@@ -1,7 +1,7 @@
 import { remoteData } from 'cbioportal-frontend-commons';
-import MobxPromise from 'mobxpromise';
 import { GENOME_BUILD } from '../util/SearchUtils';
 import client from '../util/genomeNexusClientInstance';
+import { MobxPromise } from 'cbioportal-frontend-commons';
 
 export class MainStore {
     readonly genomeBuild: MobxPromise<string> = remoteData({

--- a/src/page/Variant.tsx
+++ b/src/page/Variant.tsx
@@ -53,10 +53,10 @@ class Variant extends React.Component<IVariantProps> {
         return this.props.store.oncokbData.result;
     }
 
-    @computed
-    private get civic() {
-        return this.props.store.civicVariants.result;
-    }
+    // @computed
+    // private get civic() {
+    //     return this.props.store.civicVariants.result;
+    // }
 
     @computed
     private get variantAnnotation() {
@@ -83,7 +83,7 @@ class Variant extends React.Component<IVariantProps> {
         return (
             this.props.store.annotation.isPending ||
             this.props.store.oncokbGenesMap.isPending ||
-            this.props.store.civicVariants.isPending ||
+            // this.props.store.civicVariants.isPending ||
             this.props.store.isAnnotatedSuccessfully.isPending ||
             this.props.store.indexedAnnotation.isPending ||
             this.props.store.genomeBuild.isPending
@@ -465,7 +465,7 @@ class Variant extends React.Component<IVariantProps> {
                                     }
                                     variantAnnotation={this.variantAnnotation}
                                     oncokb={this.oncokb}
-                                    civic={this.civic}
+                                    // civic={this.civic}
                                     isCanonicalTranscriptSelected={
                                         this.isCanonicalTranscriptSelected!
                                     }

--- a/src/page/VariantStore.ts
+++ b/src/page/VariantStore.ts
@@ -1,18 +1,18 @@
 import { observable, computed, reaction, makeObservable } from 'mobx';
 import { remoteData } from 'cbioportal-frontend-commons';
 import {
-    fetchCivicVariants,
+    // fetchCivicVariants,
     genomicLocationString,
-    getCivicGenes,
-    ICivicGeneIndex,
-    ICivicVariantIndex,
+    // getCivicGenes,
+    // ICivicGeneIndex,
+    // ICivicVariantIndex,
 } from 'cbioportal-utils';
 import { VariantAnnotation } from 'genome-nexus-ts-api-client';
 import {
     IndicatorQueryResp,
     CancerGene as OncoKbGene,
 } from 'oncokb-ts-api-client';
-import MobxPromise from 'mobxpromise';
+import { MobxPromise } from 'cbioportal-frontend-commons';
 import _ from 'lodash';
 import qs from 'qs';
 import {
@@ -20,7 +20,7 @@ import {
     DataFilterType,
 } from 'react-mutation-mapper';
 import { annotationQueryFields } from '../config/configDefaults';
-import { getTranscriptConsequenceSummary } from '../util/AnnotationSummaryUtil';
+// import { getTranscriptConsequenceSummary } from '../util/AnnotationSummaryUtil';
 import { getDataFetcher } from '../util/ApiUtils';
 import genomeNexusClient from '../util/genomeNexusClientInstance';
 import oncoKbClient from '../util/oncokbClientInstance';
@@ -152,47 +152,47 @@ export class VariantStore {
         default: {},
     });
 
-    readonly civicGenes = remoteData<ICivicGeneIndex | undefined>({
-        await: () => [this.annotation],
-        invoke: async () =>
-            getCivicGenes([
-                Number(
-                    getTranscriptConsequenceSummary(this.annotationSummary)
-                        ?.entrezGeneId
-                        ? getTranscriptConsequenceSummary(
-                              this.annotationSummary
-                          )!.entrezGeneId
-                        : 0
-                ),
-            ]),
-        onError: () => {},
-    });
+    // readonly civicGenes = remoteData<ICivicGeneIndex | undefined>({
+    //     await: () => [this.annotation],
+    //     invoke: async () =>
+    //         getCivicGenes([
+    //             Number(
+    //                 getTranscriptConsequenceSummary(this.annotationSummary)
+    //                     ?.entrezGeneId
+    //                     ? getTranscriptConsequenceSummary(
+    //                           this.annotationSummary
+    //                       )!.entrezGeneId
+    //                     : 0
+    //             ),
+    //         ]),
+    //     onError: () => {},
+    // });
 
-    readonly civicVariants = remoteData<ICivicVariantIndex | undefined>({
-        await: () => [this.civicGenes],
-        invoke: async () => {
-            if (this.civicGenes.result) {
-                const mutations = variantToMutation(this.annotationSummary);
+    // readonly civicVariants = remoteData<ICivicVariantIndex | undefined>({
+    //     await: () => [this.civicGenes],
+    //     invoke: async () => {
+    //         if (this.civicGenes.result) {
+    //             const mutations = variantToMutation(this.annotationSummary);
 
-                mutations.forEach((mutation) => {
-                    // fetchCivicVariants cannot handle protein change values starting with 'p.'
-                    if (mutation.proteinChange) {
-                        mutation.proteinChange = mutation.proteinChange.replace(
-                            'p.',
-                            ''
-                        );
-                    } else {
-                        mutation.proteinChange = '';
-                    }
-                });
+    //             mutations.forEach((mutation) => {
+    //                 // fetchCivicVariants cannot handle protein change values starting with 'p.'
+    //                 if (mutation.proteinChange) {
+    //                     mutation.proteinChange = mutation.proteinChange.replace(
+    //                         'p.',
+    //                         ''
+    //                     );
+    //                 } else {
+    //                     mutation.proteinChange = '';
+    //                 }
+    //             });
 
-                return fetchCivicVariants(this.civicGenes.result, mutations);
-            } else {
-                return {};
-            }
-        },
-        onError: () => {},
-    });
+    //             return fetchCivicVariants(this.civicGenes.result, mutations);
+    //         } else {
+    //             return {};
+    //         }
+    //     },
+    //     onError: () => {},
+    // });
 
     @computed
     get annotationSummary() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2524,6 +2524,11 @@ ansi-colors@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
+ansi-colors@^4.1.1:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
+
 ansi-escapes@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -4292,21 +4297,21 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-cbioportal-frontend-commons@^0.5.51:
-  version "0.5.51"
-  resolved "https://registry.yarnpkg.com/cbioportal-frontend-commons/-/cbioportal-frontend-commons-0.5.51.tgz#726d35c7439d3cb5549a682cfbd87cd063ef15e0"
-  integrity sha512-IaXL6ViZjYtbpDMjureoYSlY1eUq1a/vq8YJVBwDJwHB+MkmNX8vakT9A8Ho0poEAXUDSURD8sG8u5INGlp4Yw==
+cbioportal-frontend-commons@^0.5.67:
+  version "0.5.67"
+  resolved "https://registry.yarnpkg.com/cbioportal-frontend-commons/-/cbioportal-frontend-commons-0.5.67.tgz#08964fc455b26908a37da2ae0c0e690005bc7032"
+  integrity sha512-wSaLHGLYYLOQum9ZuRC+yqz3ySHtcTPZjGfTRNQ12g3kIMWwGStpiKTYFFtSEA7MjH9+7icyVokHc2j0t9HSRw==
   dependencies:
     autobind-decorator "^2.1.0"
-    cbioportal-utils "^0.3.34"
+    cbioportal-utils "^0.3.41"
     classnames "^2.2.5"
     jquery "^3.2.1"
+    juice "^10.0.0"
     lodash "^4.17.15"
     measure-text "0.0.4"
-    mobxpromise "github:cbioportal/mobxpromise#303db72588860bff0a6862a4f07a4e8a3578c94f"
     numeral "^2.0.6"
     object-sizeof "^1.2.0"
-    oncokb-ts-api-client "^1.3.3"
+    oncokb-ts-api-client "^1.3.5"
     rc-tooltip "^5.0.2"
     rc-trigger "^5.2.1"
     rc-util "^5.8.0"
@@ -4314,7 +4319,7 @@ cbioportal-frontend-commons@^0.5.51:
     react-file-download "^0.3.2"
     react-overlays "0.7.4"
     react-select "^3.0.4"
-    save-svg-as-png "^1.4.6"
+    save-svg-as-png "^1.4.17"
     seamless-immutable "^7.0.1"
     superagent "^3.8.3"
     svg2pdf.js "github:cbioportal/svg2pdf.js#v1.3.3-cbio-patch-1"
@@ -4331,6 +4336,18 @@ cbioportal-utils@^0.3.34:
     genome-nexus-ts-api-client "^1.1.28"
     lodash "^4.17.15"
     oncokb-ts-api-client "^1.3.3"
+    superagent "^3.8.3"
+    typescript "4.0.3"
+
+cbioportal-utils@^0.3.41:
+  version "0.3.41"
+  resolved "https://registry.yarnpkg.com/cbioportal-utils/-/cbioportal-utils-0.3.41.tgz#32ad3df0da04c65a81d7bda4aad8c671850b08bd"
+  integrity sha512-jRaRseWV9jE+UJ5gLiC4mKVCL0GKykvRk8sJtMa5MtCg1WuHIQupbhpsWs0xjeon/HN9mmUNnyYTeeUU/ahZfA==
+  dependencies:
+    buffer "^6.0.3"
+    genome-nexus-ts-api-client "^1.1.32"
+    lodash "^4.17.15"
+    oncokb-ts-api-client "^1.3.5"
     superagent "^3.8.3"
     typescript "4.0.3"
 
@@ -4384,6 +4401,30 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+cheerio-select@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-1.6.0.tgz#489f36604112c722afa147dedd0d4609c09e1696"
+  integrity sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==
+  dependencies:
+    css-select "^4.3.0"
+    css-what "^6.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.3.1"
+    domutils "^2.8.0"
+
+cheerio@1.0.0-rc.10, cheerio@^1.0.0-rc.12:
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.10.tgz#2ba3dcdfcc26e7956fc1f440e61d51c643379f3e"
+  integrity sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==
+  dependencies:
+    cheerio-select "^1.5.0"
+    dom-serializer "^1.3.2"
+    domhandler "^4.2.0"
+    htmlparser2 "^6.1.0"
+    parse5 "^6.0.1"
+    parse5-htmlparser2-tree-adapter "^6.0.1"
+    tslib "^2.2.0"
 
 "chokidar@>=3.0.0 <4.0.0", chokidar@^3.3.0, chokidar@^3.4.1:
   version "3.5.2"
@@ -4715,6 +4756,11 @@ commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
+commander@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 common-tags@^1.8.0:
   version "1.8.0"
@@ -5115,6 +5161,17 @@ css-select@^2.0.0:
     domutils "^1.7.0"
     nth-check "^1.0.2"
 
+css-select@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.3.0.tgz#db7129b2846662fd8628cfc496abb2b59e41529b"
+  integrity sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.0.1"
+    domhandler "^4.3.1"
+    domutils "^2.8.0"
+    nth-check "^2.0.1"
+
 css-selector-tokenizer@^0.5.1:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz#139bafd34a35fd0c1428487049e0699e6f6a2c21"
@@ -5157,6 +5214,11 @@ css-what@2.1, css-what@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+
+css-what@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 css@^2.0.0:
   version "2.2.4"
@@ -5732,6 +5794,15 @@ dom-serializer@0:
     domelementtype "^1.3.0"
     entities "^1.1.1"
 
+dom-serializer@^1.0.1, dom-serializer@^1.3.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.4.1.tgz#de5d41b1aea290215dc45a6dae8adcf1d32e2d30"
+  integrity sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -5741,6 +5812,11 @@ domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+
+domelementtype@^2.0.1, domelementtype@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -5755,6 +5831,20 @@ domhandler@^2.3.0:
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
     domelementtype "1"
+
+domhandler@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.3.0.tgz#6db7ea46e4617eb15cf875df68b2b8524ce0037a"
+  integrity sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==
+  dependencies:
+    domelementtype "^2.0.1"
+
+domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
+  integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
+  dependencies:
+    domelementtype "^2.2.0"
 
 domutils@1.5.1:
   version "1.5.1"
@@ -5771,6 +5861,15 @@ domutils@^1.5.1, domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.4.2, domutils@^2.5.2, domutils@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -5911,6 +6010,11 @@ entities@^1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
+entities@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
@@ -6012,6 +6116,11 @@ escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+escape-goat@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-3.0.0.tgz#e8b5fb658553fe8a3c4959c316c6ebb8c842b19c"
+  integrity sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -6929,6 +7038,14 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+genome-nexus-ts-api-client@1.1.32, genome-nexus-ts-api-client@^1.1.32:
+  version "1.1.32"
+  resolved "https://registry.yarnpkg.com/genome-nexus-ts-api-client/-/genome-nexus-ts-api-client-1.1.32.tgz#e8a9c70d6644e17ae7f76c803ecb0d3e1720c7d9"
+  integrity sha512-ELXH+50alvUVnRioxCOLvxf5VcN57YVheF80kEVFBXT5cnO178tvDLHdaqbmAlEvezHwptercQ9kqh8d9TTm5Q==
+  dependencies:
+    superagent "^3.8.3"
+    typescript "4.0.3"
+
 genome-nexus-ts-api-client@^1.1.28:
   version "1.1.28"
   resolved "https://registry.yarnpkg.com/genome-nexus-ts-api-client/-/genome-nexus-ts-api-client-1.1.28.tgz#ead791bceffc3317081109c507539e756160da9c"
@@ -7474,6 +7591,26 @@ htmlparser2@^3.3.0:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+htmlparser2@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-5.0.1.tgz#7daa6fc3e35d6107ac95a4fc08781f091664f6e7"
+  integrity sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.3.0"
+    domutils "^2.4.2"
+    entities "^2.0.0"
+
+htmlparser2@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
+    entities "^2.0.0"
 
 http-deceiver@^1.2.7:
   version "1.2.7"
@@ -9021,6 +9158,17 @@ jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
     array-includes "^3.1.1"
     object.assign "^4.1.0"
 
+juice@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/juice/-/juice-10.0.0.tgz#c6b717ded8be4b969f12503ac9cfbd2604d35937"
+  integrity sha512-9f68xmhGrnIi6DBkiiP3rUrQN33SEuaKu1+njX6VgMP+jwZAsnT33WIzlrWICL9matkhYu3OyrqSUP55YTIdGg==
+  dependencies:
+    cheerio "^1.0.0-rc.12"
+    commander "^6.1.0"
+    mensch "^0.3.4"
+    slick "^1.12.2"
+    web-resource-inliner "^6.0.1"
+
 keycode@^2.1.2:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.1.tgz#09c23b2be0611d26117ea2501c2c391a01f39eff"
@@ -9647,6 +9795,11 @@ memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
+mensch@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/mensch/-/mensch-0.3.4.tgz#770f91b46cb16ea5b204ee735768c3f0c491fecd"
+  integrity sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g==
+
 merge-deep@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/merge-deep/-/merge-deep-3.0.2.tgz#f39fa100a4f1bd34ff29f7d2bf4508fbb8d83ad2"
@@ -10035,6 +10188,11 @@ mime@^2.4.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
 
+mime@^2.4.6:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -10176,12 +10334,6 @@ mobx@^6.0.0:
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.3.2.tgz#125590961f702a572c139ab69392bea416d2e51b"
   integrity sha512-xGPM9dIE1qkK9Nrhevp0gzpsmELKU4MFUJRORW/jqxVFIHHWIoQrjDjL8vkwoJYY3C2CeVJqgvl38hgKTalTWg==
 
-"mobxpromise@github:cbioportal/mobxpromise#303db72588860bff0a6862a4f07a4e8a3578c94f":
-  version "2.0.1"
-  resolved "https://codeload.github.com/cbioportal/mobxpromise/tar.gz/303db72588860bff0a6862a4f07a4e8a3578c94f"
-  dependencies:
-    mobx "^6.0.0"
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -10308,6 +10460,13 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.6.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -10478,6 +10637,13 @@ nth-check@^1.0.2, nth-check@~1.0.1:
   integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
   dependencies:
     boolbase "~1.0.0"
+
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -10678,6 +10844,22 @@ oncokb-frontend-commons@^0.0.18:
     react-if "^2.1.0"
     react-table "^6.10.0"
 
+oncokb-frontend-commons@^0.0.25:
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/oncokb-frontend-commons/-/oncokb-frontend-commons-0.0.25.tgz#f4be188fd85935b3844c6cba09fa305a7669d36d"
+  integrity sha512-fzOjPR9fWZY7DXflUFdHU7tXd+ZEsPkk1pX+I6ofYMnLAebRSbPY6DDmk4Chifa5OyY93m40+AlKb/AVkIQlWg==
+  dependencies:
+    cbioportal-utils "^0.3.41"
+    classnames "^2.2.5"
+    lodash "^4.17.15"
+    oncokb-styles "~1.4.2"
+    oncokb-ts-api-client "^1.3.5"
+    rc-tooltip "^5.0.2"
+    react-bootstrap "^0.31.5"
+    react-collapse "^4.0.3"
+    react-if "^2.1.0"
+    react-table "^6.10.0"
+
 oncokb-styles@~1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/oncokb-styles/-/oncokb-styles-1.4.2.tgz#ad601699636875abe425d80b25c050d28d47c2bc"
@@ -10695,6 +10877,14 @@ oncokb-ts-api-client@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/oncokb-ts-api-client/-/oncokb-ts-api-client-1.3.3.tgz#4596894332553e9df4b121007e80528b3a684d0c"
   integrity sha512-hA5Vfuub9lHCnmQgzFASbvbn2ud4ri9vcbfXcjn3EEfXTDIhAaTpCjaD1zkbW3fMAabY9D7abnKNM4wwmBnbcA==
+  dependencies:
+    superagent "^3.8.3"
+    typescript "4.0.3"
+
+oncokb-ts-api-client@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/oncokb-ts-api-client/-/oncokb-ts-api-client-1.3.5.tgz#c829eed16482f7499641701c1cc3a6787f55fdb8"
+  integrity sha512-LPA6hyPZAqBcO3/f6s9TxdEWRFcEpDN3x7nkaxdtq0GJMyoV/ha7CoLiLZ7ja+LhzVGKFYgV5j7ZyO0wvy59ow==
   dependencies:
     superagent "^3.8.3"
     typescript "4.0.3"
@@ -10963,6 +11153,13 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse5-htmlparser2-tree-adapter@^6.0.0, parse5-htmlparser2-tree-adapter@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
+  dependencies:
+    parse5 "^6.0.1"
+
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
@@ -10978,7 +11175,7 @@ parse5@^1.5.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
   integrity sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=
 
-parse5@^6.0.0:
+parse5@^6.0.0, parse5@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
@@ -12706,23 +12903,22 @@ react-motion@^0.5.2:
     prop-types "^15.5.8"
     raf "^3.1.0"
 
-react-mutation-mapper@^0.8.93:
-  version "0.8.93"
-  resolved "https://registry.yarnpkg.com/react-mutation-mapper/-/react-mutation-mapper-0.8.93.tgz#81f1ee4a151b3da279613d4e4914d06ba56c525f"
-  integrity sha512-4PhuH86DObFvDM6kI4RViij0gAzuiJuv9a/G49/fSvibdbzPtG7YVJU8qa5rrTBSZ5htZJ8y36u5W1zq/OoKEw==
+react-mutation-mapper@^0.8.110:
+  version "0.8.110"
+  resolved "https://registry.yarnpkg.com/react-mutation-mapper/-/react-mutation-mapper-0.8.110.tgz#be526612c5bc7734ea5a700bfbbaae04c0718e01"
+  integrity sha512-vJrEPqQGWwFgZKDwkrcZe37LY0WeB7en4P1M0SbHwrqr09mLhEtKwsZK7aNlm3OHmJbmTJ7kMlXfRAr5FHYSnw==
   dependencies:
     autobind-decorator "^2.1.0"
-    cbioportal-frontend-commons "^0.5.51"
-    cbioportal-utils "^0.3.34"
+    cbioportal-frontend-commons "^0.5.67"
+    cbioportal-utils "^0.3.41"
     classnames "^2.2.5"
-    genome-nexus-ts-api-client "^1.1.28"
+    genome-nexus-ts-api-client "^1.1.32"
     jquery "^3.2.1"
     lodash "^4.17.15"
     memoize-weak-decorator "^1.0.3"
-    mobxpromise "github:cbioportal/mobxpromise#303db72588860bff0a6862a4f07a4e8a3578c94f"
-    oncokb-frontend-commons "^0.0.18"
+    oncokb-frontend-commons "^0.0.25"
     oncokb-styles "~1.4.2"
-    oncokb-ts-api-client "^1.3.3"
+    oncokb-ts-api-client "^1.3.5"
     react-collapse "^4.0.3"
     react-if "^2.1.0"
     react-motion "^0.5.2"
@@ -13639,10 +13835,10 @@ sass@^1.32.4:
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 
-save-svg-as-png@^1.4.6:
-  version "1.4.14"
-  resolved "https://registry.yarnpkg.com/save-svg-as-png/-/save-svg-as-png-1.4.14.tgz#d5017bb9746adf00c146a17e63ed4badd1e10b40"
-  integrity sha512-hJqOFSdRvhBVD2pQSM+mJStvQGfnvQCCF6ULtAxdjF4lDwXYfWZ9Eug0fcRl05YyPL2yknCDBEOpbO4Fkw5qmg==
+save-svg-as-png@^1.4.17:
+  version "1.4.17"
+  resolved "https://registry.yarnpkg.com/save-svg-as-png/-/save-svg-as-png-1.4.17.tgz#294442002772a24f1db1bf8a2aaf7df4ab0cdc55"
+  integrity sha512-7QDaqJsVhdFPwviCxkgHiGm9omeaMBe1VKbHySWU6oFB2LtnGCcYS13eVoslUgq6VZC6Tjq/HddBd1K6p2PGpA==
 
 sax@^1.1.4, sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"
@@ -13913,6 +14109,11 @@ slice-ansi@^2.1.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
+
+slick@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/slick/-/slick-1.12.2.tgz#bd048ddb74de7d1ca6915faa4a57570b3550c2d7"
+  integrity sha512-4qdtOGcBjral6YIBCWJ0ljFSKNLz9KkhbWtuGvUyRowl1kxfuE1x/Z/aJcaiilpb3do9bl5K7/1h9XC5wWpY/A==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -14766,6 +14967,11 @@ tslib@^2.0.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
+tslib@^2.2.0:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
+  integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
+
 tsutils@^3.17.1:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -15206,6 +15412,11 @@ v8flags@^2.1.1:
   dependencies:
     user-home "^1.1.1"
 
+valid-data-url@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/valid-data-url/-/valid-data-url-3.0.1.tgz#826c1744e71b5632e847dd15dbd45b9fb38aa34f"
+  integrity sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -15627,6 +15838,18 @@ web-namespaces@^2.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
+web-resource-inliner@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/web-resource-inliner/-/web-resource-inliner-6.0.1.tgz#df0822f0a12028805fe80719ed52ab6526886e02"
+  integrity sha512-kfqDxt5dTB1JhqsCUQVFDj0rmY+4HLwGQIsLPbyrsN9y9WV/1oFDSx3BQ4GfCv9X+jVeQ7rouTqwK53rA/7t8A==
+  dependencies:
+    ansi-colors "^4.1.1"
+    escape-goat "^3.0.0"
+    htmlparser2 "^5.0.0"
+    mime "^2.4.6"
+    node-fetch "^2.6.0"
+    valid-data-url "^3.0.0"
+
 webidl-conversions@^3.0.0, webidl-conversions@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -15824,6 +16047,14 @@ whatwg-url@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-2.0.1.tgz#5396b2043f020ee6f704d9c45ea8519e724de659"
   integrity sha1-U5ayBD8CDub3BNnEXqhRnnJN5lk=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"


### PR DESCRIPTION
Updates:
1. Hide civic
2. Fix reVUE to fit new genome nexus model
3. Update packages - set cheerio and parse5 version in resolutions, because the 'juice' dependency in cbioportal frontend commons causes some conficts, using older version of cheerio and parse5 is a temp fix.