### PR TITLE
Demo: vibe-vep as backend replacement

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 # using GRCh37 Genome Nexus by default:
-REACT_APP_GENOME_NEXUS_URL=https://www.genomenexus.org
+REACT_APP_GENOME_NEXUS_URL=https://vibe-vep.genomenexus.org/genome-nexus/grch37
 # GRCh38 Genome Nexus url:
 # REACT_APP_GENOME_NEXUS_URL=https://grch38.genomenexus.org

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 # using GRCh37 Genome Nexus by default:
-REACT_APP_GENOME_NEXUS_URL=https://vibe-vep.genomenexus.org/genome-nexus/grch37
+REACT_APP_GENOME_NEXUS_URL=https://vibe-vep.genomenexus.org/genome-nexus/grch38
 # GRCh38 Genome Nexus url:
 # REACT_APP_GENOME_NEXUS_URL=https://grch38.genomenexus.org

--- a/src/component/variantPage/BasicInfo.tsx
+++ b/src/component/variantPage/BasicInfo.tsx
@@ -17,7 +17,7 @@ import TranscriptSummaryTable from './TranscriptSummaryTable';
 import { generateOncokbLink, ONCOKB_URL } from './biologicalFunction/Oncokb';
 
 import basicInfo from './BasicInfo.module.scss';
-import { Link } from 'react-router-dom';
+import { genomeNexusApiRoot } from '../../util/genomeNexusClientInstance';
 import { annotationQueryFields } from '../../config/configDefaults';
 import Toggle from '../Toggle';
 import { ReVUEContent } from './biologicalFunction/ReVUE';
@@ -377,16 +377,17 @@ export default class BasicInfo extends React.Component<IBasicInfoProps> {
                     </span>
                 }
             >
-                <Link
-                    to={`/annotation/${
-                        this.props.variant
+                <a
+                    href={`${genomeNexusApiRoot}/annotation/${
+                        encodeURIComponent(this.props.variant)
                     }?fields=${annotationQueryFields().join(',')}`}
                     target="_blank"
+                    rel="noopener noreferrer"
                     style={{ paddingLeft: '8px', paddingRight: '8px' }}
                 >
                     {'JSON '}
                     <i className="fa fa-external-link" />
-                </Link>
+                </a>
             </DefaultTooltip>
         );
     }


### PR DESCRIPTION
## Summary

Points the frontend at [vibe-vep](https://github.com/inodb/vibe-vep) (`vibe-vep.genomenexus.org/genome-nexus/grch37`) as a drop-in replacement for the genome-nexus Java backend.

**This is a demo PR** — use the Netlify preview to explore how the frontend works with vibe-vep as the annotation engine.

## What works

- Gene symbol, consequence, HGVSp/HGVSc notation
- SIFT and PolyPhen-2 predictions
- ClinVar clinical significance
- `annotation_summary` (canonical transcript, variantClassification, hgvspShort, variantType)
- HGNC ID and Ensembl protein ID per transcript
- All Ensembl VEP and genome-nexus compatible endpoints

## Known gaps (sections that will show empty)

- gnomAD frequencies — `my_variant_info` not yet implemented (needs myvariant.info proxy)
- dbSNP RS IDs — same
- SIGNAL germline data — data exists but not yet exposed via `?fields=signal`
- Cancer hotspots — loaded but transcript coordinate mismatch (inodb/vibe-vep#8)
- Mutation Assessor — not implemented
- entrezGeneId, refSeq — not yet available (inodb/vibe-vep#9)

## Test URLs

Try these in the Netlify preview:
- `7:g.140453136A>T` (BRAF V600E)
- `17:g.41244936G>A` (BRCA1)
- `12:g.25398284C>A` (KRAS G12C)